### PR TITLE
Fixes #60: Added an option to create teams on the dashboard's "Teams" section

### DIFF
--- a/packages/stack-server/src/app/(main)/(protected)/projects/[projectId]/teams/page-client.tsx
+++ b/packages/stack-server/src/app/(main)/(protected)/projects/[projectId]/teams/page-client.tsx
@@ -1,16 +1,62 @@
 "use client";
+import React from "react";
 import { useAdminApp } from "../use-admin-app";
 import { PageLayout } from "../page-layout";
 import { TeamTable } from "@/components/data-table/team-table";
+import { Button } from "@/components/ui/button";
+import { SmartFormDialog } from "@/components/form-dialog";
+import * as yup from "yup";
 
+type CreateDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
 
 export default function PageClient() {
   const stackAdminApp = useAdminApp();
   const teams = stackAdminApp.useTeams();
 
+  const [createTeamsOpen, setCreateTeamsOpen] = React.useState(false);
+ 
   return (
-    <PageLayout title="Teams">
+    <PageLayout
+      title="Teams"
+      actions={
+        <Button onClick={() => setCreateTeamsOpen(true)}>
+          Create Team
+        </Button>
+      }>
       <TeamTable teams={teams} />
+      <CreateDialog
+        open={createTeamsOpen}
+        onOpenChange={setCreateTeamsOpen}
+      />
     </PageLayout>
+  );
+}
+
+function CreateDialog({ open, onOpenChange }: CreateDialogProps) {
+  const stackAdminApp = useAdminApp();
+ 
+
+  const formSchema = yup.object({
+    displayName: yup.string().required().label("Display Name"),
+    
+  });
+
+  return (
+    <SmartFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Create a Team"
+      formSchema={formSchema}
+      okButton={{ label: "Save" }}
+      onSubmit={async (values) => {
+        await stackAdminApp.createTeam({
+          displayName: values.displayName,
+        });
+      }}
+      cancelButton
+    />
   );
 }

--- a/packages/stack-server/src/app/(main)/(protected)/projects/[projectId]/teams/page-client.tsx
+++ b/packages/stack-server/src/app/(main)/(protected)/projects/[projectId]/teams/page-client.tsx
@@ -8,8 +8,8 @@ import { SmartFormDialog } from "@/components/form-dialog";
 import * as yup from "yup";
 
 type CreateDialogProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
 };
 
 export default function PageClient() {
@@ -41,7 +41,6 @@ function CreateDialog({ open, onOpenChange }: CreateDialogProps) {
 
   const formSchema = yup.object({
     displayName: yup.string().required().label("Display Name"),
-    
   });
 
   return (

--- a/packages/stack-server/src/components/form-fields.tsx
+++ b/packages/stack-server/src/components/form-fields.tsx
@@ -43,6 +43,7 @@ export function InputField<F extends FieldValues>(props: {
             <FormControl>
               <Input
                 {...field} 
+                value={field.value ?? ""}
                 placeholder={props.placeholder} 
                 className="max-w-lg" 
                 disabled={props.disabled} 


### PR DESCRIPTION
### Fixes Issue #60

#### Description
I've added an option to create teams on the dashboard's "Teams" section. I've created a pull request for your review. Please let me know if this is what you envisioned. If not, I'm happy to make further adjustments.

#### Changes Made
- Updated `teams>page.client.tsx` to include the button to create teams.

#### Additional Notes
- No new dependencies were added.