### PR TITLE
Fix password mismatch issue on Safari

### DIFF
--- a/packages/stack/src/components/credential-sign-up.tsx
+++ b/packages/stack/src/components/credential-sign-up.tsx
@@ -23,8 +23,13 @@ const schema = yup.object().shape({
       }
     }
   }),
-  passwordRepeat: yup.string().nullable().oneOf([yup.ref('password'), null], 'Passwords do not match').required('Please repeat your password')
+  passwordRepeat: yup.string()
+    .required('Please repeat your password')
+    .test('passwords-match', 'Passwords do not match', function (value) {
+      return value === this.resolve(yup.ref('password')) || value === null;
+    })
 });
+
 
 export default function CredentialSignUp() {
   const { register, handleSubmit, setError, formState: { errors }, clearErrors } = useForm({
@@ -39,8 +44,8 @@ export default function CredentialSignUp() {
   };
 
   return (
-    <form 
-      style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch' }} 
+    <form
+      style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch' }}
       onSubmit={e => runAsynchronouslyWithAlert(handleSubmit(onSubmit)(e))}
       noValidate
     >
@@ -62,7 +67,7 @@ export default function CredentialSignUp() {
         }}
       />
       <FormWarningText text={errors.password?.message?.toString()} />
-        
+
       <Label htmlFor="repeat-password" style={{ marginTop: '1rem' }}>Repeat Password</Label>
       <PasswordField
         id="repeat-password"


### PR DESCRIPTION
### Fixes issue#72 https://github.com/stack-auth/stack/issues/72#issue-2344036610
**Basically the problem was one of them was string and the other was not and that was giving the error password do not match**
**video was too big so had to compress it to zip you can see that it works**
**_Working_Video_**
[Screen Recording 2024-06-17 at 7.19.10 PM 2.zip](https://github.com/user-attachments/files/15875355/Screen.Recording.2024-06-17.at.7.19.10.PM.2.zip)

**Where the password actually isnt a  match**
<img width="505" alt="Screenshot 2024-06-17 at 11 51 36 PM" src="https://github.com/stack-auth/stack/assets/119395914/835a6a4a-2843-485e-87c8-f6f70687cc0f">

