### PR TITLE
fix docs generation on windows

### DIFF
--- a/apps/backend/scripts/generate-docs.ts
+++ b/apps/backend/scripts/generate-docs.ts
@@ -7,7 +7,7 @@ import { isSmartRouteHandler } from '@/route-handlers/smart-route-handler';
 
 async function main() {
   for (const audience of ['client', 'server'] as const) {
-    const filePathPrefix = "src/app/api/v1";
+    const filePathPrefix = "apps/src/app/api/v1";
     const importPathPrefix = "@/app/api/v1";
     const filePaths = await glob(filePathPrefix + "/**/route.{js,jsx,ts,tsx}");
     const openAPISchema = yaml.stringify(parseOpenAPI({


### PR DESCRIPTION
Fixes the error in the documentation generation for Windows.

Error message:

This was the error generated on running ``pnpm generate-docs``.
![image](https://github.com/stack-auth/stack/assets/100564488/758bc3c4-7102-4193-8a5b-e1a06998dea9)

So, I fixed the path in in `apps/backend/scripts/generate-docs.ts`.