### PR TITLE
add chat support bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ If you make changes to the Prisma schema, you need to run the following command 
 pnpm run prisma migrate dev
 ```
 
+### Chat with the codebase
+
+Storia trained an [AI on our codebase](https://sage.storia.ai/stack-auth) that can answer questions about using and contributing to Stack.
+
 ### Architecture overview
 
 ```mermaid
@@ -192,7 +196,7 @@ pnpm run prisma migrate dev
       class ExternalOAuth,Svix external
 ```
 
-Thanks to [CodeViz](https://www.codeviz.ai) for generating the diagram! If you want to chat with the Stack repository to get a high level overview of how it is structured and how to build off it, check out [Sage](https://sage.storia.ai).
+Thanks to [CodeViz](https://www.codeviz.ai) for generating the diagram!
 
 ## ❤️ Contributors
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ pnpm run prisma migrate dev
       class ExternalOAuth,Svix external
 ```
 
-Thanks to [CodeViz](https://www.codeviz.ai) for generating the diagram!
+Thanks to [CodeViz](https://www.codeviz.ai) for generating the diagram! If you want to chat with the Stack repository to get a high level overview of how it is structured and how to build off it, check out [Sage](https://sage.storia.ai).
 
 ## ❤️ Contributors
 


### PR DESCRIPTION
Stack is publicly indexed and available for chat on Storia Sage. I thought this would be helpful for users of Stack to get support questions answered quickly.
