### PR TITLE
fix overflow issue with long team names

### DIFF
--- a/packages/stack/src/components-page/account-settings.tsx
+++ b/packages/stack/src/components-page/account-settings.tsx
@@ -78,9 +78,9 @@ export function AccountSettings(props: {
               type: 'divider',
             }] as const : [],
             ...teams.map(team => ({
-              title: <div className='flex gap-2 items-center'>
+              title: <div className='flex gap-2 items-center w-full'>
                 <TeamIcon team={team}/>
-                {team.displayName}
+                <Typography className="max-w-[320px] md:w-[90%] truncate">{team.displayName}</Typography>
               </div>,
               type: 'item',
               subpath: `/teams/${team.id}`,

--- a/packages/stack/src/components/elements/sidebar-layout.tsx
+++ b/packages/stack/src/components/elements/sidebar-layout.tsx
@@ -46,7 +46,7 @@ function Items(props: { items: SidebarItem[], basePath: string, selectedIndex: n
         size='sm'
         className={cn(
           props.selectedIndex === index && "bg-muted",
-          "justify-start text-md text-zinc-800 dark:text-zinc-300 px-2",
+          "justify-start text-md text-zinc-800 dark:text-zinc-300 px-2 text-left",
         )}
         onClick={() => {
           if (item.subpath) {


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack/blob/dev/CONTRIBUTING.md

-->

This PR fixes an issue where long team names would overflow their container in the UI. The changes ensure that team names are properly truncated.

![mobile](https://github.com/user-attachments/assets/40943fd3-e5e9-4c89-b684-89d883f6d53c)
![desktop](https://github.com/user-attachments/assets/185b82ad-d992-4bce-82a5-378b5bd4cb65)
