### PR TITLE
added success and destructive variants in toast file for colorful toasts

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/emails/templates/[type]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/emails/templates/[type]/page-client.tsx
@@ -35,8 +35,11 @@ export default function PageClient(props: { templateType: EmailTemplateType }) {
   }
 
   const onSave = async (document: TEditorConfiguration, subject: string) => {
-    await app.updateEmailTemplate(props.templateType, { content: document, subject });
-    toast({ title: "Email template saved" });
+    await app.updateEmailTemplate(props.templateType, {
+      content: document,
+      subject,
+    });
+    toast({ title: 'Email template saved', variant: 'success' });
   };
 
   const onCancel = () => {

--- a/apps/dashboard/src/components/dev-error-notifier.tsx
+++ b/apps/dashboard/src/components/dev-error-notifier.tsx
@@ -31,6 +31,7 @@ export function DevErrorNotifier() {
       toast.toast({
         title: `[DEV] console.${prop} called!`,
         description: `Please check the browser console. ${args.join(" ")}`,
+        variant: "destructive",
       });
     };
     callbacks.push(cb);

--- a/apps/dashboard/src/components/feedback-dialog.tsx
+++ b/apps/dashboard/src/components/feedback-dialog.tsx
@@ -52,6 +52,7 @@ export function FeedbackDialog(props: {
       toast({
         title: "Feedback sent",
         description: "We'll get back to you soon",
+        variant: "success"
       });
     }}
   />;

--- a/apps/dashboard/src/components/settings.tsx
+++ b/apps/dashboard/src/components/settings.tsx
@@ -150,7 +150,7 @@ export function FormSettingCard<F extends FieldValues>(
     try {
       await props.onSubmit(values);
       form.reset();
-      toast({ title: "Your changes have been saved", variant: "success" });
+      toast({ title: 'Your changes have been saved', variant: 'success' });
     } finally {
       setSubmitting(false);
     }

--- a/apps/dashboard/src/components/settings.tsx
+++ b/apps/dashboard/src/components/settings.tsx
@@ -150,7 +150,7 @@ export function FormSettingCard<F extends FieldValues>(
     try {
       await props.onSubmit(values);
       form.reset();
-      toast({ title: "Your changes have been saved" });
+      toast({ title: "Your changes have been saved", variant: "success" });
     } finally {
       setSubmitting(false);
     }

--- a/packages/stack-emails/src/editor/template-panel/import-json/import-json-dialog.tsx
+++ b/packages/stack-emails/src/editor/template-panel/import-json/import-json-dialog.tsx
@@ -33,7 +33,7 @@ export default function ImportJsonDialog({ onClose }: ImportJsonDialogProps) {
           }
           resetDocument(data);
           onClose();
-          toast({ title: 'Imported JSON' });
+          toast({ title: 'Imported JSON', variant: 'success' });
         },
         props: {
           disabled: error !== null,

--- a/packages/stack-ui/src/components/copy-button.tsx
+++ b/packages/stack-ui/src/components/copy-button.tsx
@@ -20,7 +20,7 @@ const CopyButton = React.forwardRef<
         await props.onClick?.(...args);
         try {
           await navigator.clipboard.writeText(props.content);
-          toast({ description: 'Copied to clipboard!' });
+          toast({ description: 'Copied to clipboard!', variant: 'success' });
         } catch (e) {
           toast({ description: 'Failed to copy to clipboard', variant: 'destructive' });
         }

--- a/packages/stack-ui/src/components/ui/inline-code.tsx
+++ b/packages/stack-ui/src/components/ui/inline-code.tsx
@@ -25,7 +25,7 @@ const InlineCode = React.forwardRef<
         runAsynchronously(async () => {
           try {
             await navigator.clipboard.writeText(getNodeText(props.children));
-            toast({ description: 'Copied to clipboard!' });
+            toast({ description: 'Copied to clipboard!', variant: 'success' });
           } catch (e) {
             toast({ description: 'Failed to copy to clipboard', variant: 'destructive' });
           }

--- a/packages/stack-ui/src/components/ui/toast.tsx
+++ b/packages/stack-ui/src/components/ui/toast.tsx
@@ -29,9 +29,12 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: "border bg-background text-foreground",
+        default:
+          "border border-border bg-background text-foreground shadow-lg dark:border-gray-600 dark:bg-gray-800 dark:text-foreground",
         destructive:
-          "destructive group border-destructive bg-destructive text-destructive-foreground",
+          "group border border-destructive bg-destructive text-destructive-foreground shadow-lg dark:border-destructive dark:bg-destructive dark:text-destructive-foreground",
+        success:
+          "group border border-success bg-success text-success-foreground shadow-lg dark:border-success dark:bg-success dark:text-success-foreground",
       },
     },
     defaultVariants: {
@@ -112,9 +115,9 @@ const ToastDescription = React.forwardRef<
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
 
-type ToastActionElement = React.ReactElement<typeof ToastAction>
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
   type ToastProps,

--- a/packages/stack-ui/src/components/ui/toast.tsx
+++ b/packages/stack-ui/src/components/ui/toast.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import React from "react";
 import { Cross2Icon } from "@radix-ui/react-icons";
@@ -32,9 +32,9 @@ const toastVariants = cva(
         default:
           "border border-border bg-background text-foreground shadow-lg dark:border-gray-600 dark:bg-gray-800 dark:text-foreground",
         destructive:
-          "group border border-destructive bg-destructive text-destructive-foreground shadow-lg dark:border-destructive dark:bg-destructive dark:text-destructive-foreground",
+          'destructive group border-destructive bg-destructive text-destructive-foreground',
         success:
-          "group border border-success bg-success text-success-foreground shadow-lg dark:border-success dark:bg-success dark:text-success-foreground",
+          'success group border-success bg-success text-success-foreground',
       },
     },
     defaultVariants: {
@@ -80,10 +80,12 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100',
+      'group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      'group-[.success]:text-green-300 group-[.success]:hover:text-green-50 group-[.success]:focus:ring-green-400 group-[.success]:focus:ring-offset-green-600',
       className
     )}
-    toast-close=""
+    toast-close=''
     {...props}
   >
     <Cross2Icon className="h-4 w-4" />


### PR DESCRIPTION
#270 

Added success and destructive variants toast colors
Supports dark mode
Adde variant: "success"  to the success toasts

![image](https://github.com/user-attachments/assets/77f10bcf-2e8e-4c36-85ff-fc9149557abc)

