### PR TITLE
Removed client id unique constraint

### DIFF
--- a/apps/backend/prisma/migrations/20241013185548_remove_client_id_unique/migration.sql
+++ b/apps/backend/prisma/migrations/20241013185548_remove_client_id_unique/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "StandardOAuthProviderConfig_projectConfigId_clientId_key";

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -468,8 +468,6 @@ model StandardOAuthProviderConfig {
 
   // each type of standard OAuth provider can only be used once per project
   @@id([projectConfigId, id])
-  // each client id can only be used once per project
-  @@unique([projectConfigId, clientId])
 }
 
 model AuthMethod {


### PR DESCRIPTION
It doesn't seem necessary to enforce that at the DB level. This also causes some 500 errors on Sentry.