### PR TITLE
Neon project provision

### DIFF
--- a/apps/backend/prisma/migrations/20241207223510_neon_project_transfers/migration.sql
+++ b/apps/backend/prisma/migrations/20241207223510_neon_project_transfers/migration.sql
@@ -1,0 +1,15 @@
+-- AlterEnum
+ALTER TYPE "VerificationCodeType" ADD VALUE 'NEON_INTEGRATION_PROJECT_TRANSFER';
+
+-- CreateTable
+CREATE TABLE "NeonProvisionedProject" (
+    "projectId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "neonClientId" TEXT NOT NULL,
+
+    CONSTRAINT "NeonProvisionedProject_pkey" PRIMARY KEY ("projectId")
+);
+
+-- AddForeignKey
+ALTER TABLE "NeonProvisionedProject" ADD CONSTRAINT "NeonProvisionedProject_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -32,6 +32,8 @@ model Project {
   authMethods       AuthMethod[]
   contactChannels   ContactChannel[]
   connectedAccounts ConnectedAccount[]
+
+  neonProvisionedProject NeonProvisionedProject?
 }
 
 // Contains all the configuration for a project.
@@ -718,6 +720,7 @@ enum VerificationCodeType {
   MFA_ATTEMPT
   PASSKEY_REGISTRATION_CHALLENGE
   PASSKEY_AUTHENTICATION_CHALLENGE
+  NEON_INTEGRATION_PROJECT_TRANSFER
 }
 
 //#region API keys
@@ -833,6 +836,18 @@ model IdPAdapterData {
   @@id([idpId, model, id])
   @@index([payload(ops: JsonbPathOps)], type: Gin)
   @@index([expiresAt])
+}
+//#endregion
+
+//#region Neon integration
+model NeonProvisionedProject {
+  projectId String @id
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  neonClientId String
 }
 //#endregion
 

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -139,6 +139,7 @@ async function seed() {
       } else {
         const newUser = await tx.projectUser.create({
           data: {
+            displayName: 'Administrator (created by seed script)',
             projectUserId: '33e7c043-d2d1-4187-acd3-f91b5ed64b46',
             projectId: 'internal',
             serverMetadata: adminInternalAccess

--- a/apps/backend/src/app/api/v1/integrations/neon/oauth/token/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/oauth/token/route.tsx
@@ -1,6 +1,6 @@
 import { prismaClient } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
-import { yupMixed, yupNumber, yupObject, yupString, yupTuple, yupUnion } from "@stackframe/stack-shared/dist/schema-fields";
+import { neonAuthorizationHeaderSchema, yupMixed, yupNumber, yupObject, yupString, yupTuple, yupUnion } from "@stackframe/stack-shared/dist/schema-fields";
 import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
 
@@ -17,7 +17,7 @@ export const POST = createSmartRouteHandler({
       redirect_uri: yupString().defined(),
     }).defined(),
     headers: yupObject({
-      authorization: yupTuple([yupString().defined()]).defined(),
+      authorization: yupTuple([neonAuthorizationHeaderSchema.defined()]).defined(),
     }).defined(),
   }),
   response: yupUnion(

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/provision/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/provision/route.tsx
@@ -1,0 +1,64 @@
+import { createApiKeySet } from "@/lib/api-keys";
+import { createProject } from "@/lib/projects";
+import { prismaClient } from "@/prisma-client";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { neonAuthorizationHeaderSchema, projectDisplayNameSchema, yupNumber, yupObject, yupString, yupTuple } from "@stackframe/stack-shared/dist/schema-fields";
+import { decodeBase64 } from "@stackframe/stack-shared/dist/utils/bytes";
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    hidden: true,
+  },
+  request: yupObject({
+    body: yupObject({
+      display_name: projectDisplayNameSchema.defined(),
+    }).defined(),
+    headers: yupObject({
+      authorization: yupTuple([neonAuthorizationHeaderSchema.defined()]).defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      project_id: yupString().defined(),
+      super_secret_admin_key: yupString().defined(),
+    }).defined(),
+  }),
+  handler: async (req) => {
+    const { authorization } = req.headers;
+    const encoded = authorization[0].split(' ')[1];
+    const decoded = new TextDecoder().decode(decodeBase64(encoded));
+    const clientId = decoded.split(':')[0];
+
+    const createdProject = await createProject([], {
+      display_name: req.body.display_name,
+      description: "Created with Neon",
+    });
+
+    await prismaClient.neonProvisionedProject.create({
+      data: {
+        projectId: createdProject.id,
+        neonClientId: clientId,
+      },
+    });
+
+    const set = await createApiKeySet({
+      projectId: createdProject.id,
+      description: "Auto-generated for Neon",
+      expires_at_millis: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365 * 100).getTime(),
+      has_publishable_client_key: false,
+      has_secret_server_key: false,
+      has_super_secret_admin_key: true,
+    });
+
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        project_id: createdProject.id,
+        super_secret_admin_key: set.super_secret_admin_key!,
+      },
+    };
+  },
+});

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/provision/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/provision/route.tsx
@@ -26,7 +26,7 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   handler: async (req) => {
-    const [clientId, clientSecret] = decodeBasicAuthorizationHeader(req.headers.authorization[0])!;
+    const [clientId] = decodeBasicAuthorizationHeader(req.headers.authorization[0])!;
 
     const createdProject = await createProject([], {
       display_name: req.body.display_name,

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/provision/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/provision/route.tsx
@@ -3,7 +3,7 @@ import { createProject } from "@/lib/projects";
 import { prismaClient } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { neonAuthorizationHeaderSchema, projectDisplayNameSchema, yupNumber, yupObject, yupString, yupTuple } from "@stackframe/stack-shared/dist/schema-fields";
-import { decodeBase64 } from "@stackframe/stack-shared/dist/utils/bytes";
+import { decodeBasicAuthorizationHeader } from "@stackframe/stack-shared/dist/utils/http";
 
 export const POST = createSmartRouteHandler({
   metadata: {
@@ -26,10 +26,7 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   handler: async (req) => {
-    const { authorization } = req.headers;
-    const encoded = authorization[0].split(' ')[1];
-    const decoded = new TextDecoder().decode(decodeBase64(encoded));
-    const clientId = decoded.split(':')[0];
+    const [clientId, clientSecret] = decodeBasicAuthorizationHeader(req.headers.authorization[0])!;
 
     const createdProject = await createProject([], {
       display_name: req.body.display_name,

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/confirm/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/confirm/route.tsx
@@ -1,0 +1,3 @@
+import { neonIntegrationProjectTransferCodeHandler } from "./verification-code-handler";
+
+export const POST = neonIntegrationProjectTransferCodeHandler.postHandler;

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/confirm/verification-code-handler.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/confirm/verification-code-handler.tsx
@@ -1,0 +1,79 @@
+import { prismaClient } from "@/prisma-client";
+import { createVerificationCodeHandler } from "@/route-handlers/verification-code-handler";
+import { VerificationCodeType } from "@prisma/client";
+import { KnownErrors } from "@stackframe/stack-shared";
+import { yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { StatusError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+
+export const neonIntegrationProjectTransferCodeHandler = createVerificationCodeHandler({
+  metadata: {
+    post: {
+      hidden: true,
+    },
+  },
+  type: VerificationCodeType.NEON_INTEGRATION_PROJECT_TRANSFER,
+  data: yupObject({
+    neon_client_id: yupString().defined(),
+    project_id: yupString().defined(),
+  }).defined(),
+  method: yupObject({}),
+  requestBody: yupObject({}),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      project_id: yupString().defined(),
+    }).defined(),
+  }),
+  async handler(project, method, data, body, user) {
+    if (project.id !== "internal") throw new StatusError(400, "This endpoint is only available for internal projects.");
+    if (!user) throw new KnownErrors.UserAuthenticationRequired;
+
+    await prismaClient.$transaction(async (tx) => {
+      const neonProvisionedProject = await tx.neonProvisionedProject.deleteMany({
+        where: {
+          projectId: data.project_id,
+          neonClientId: data.neon_client_id,
+        },
+      });
+
+      if (neonProvisionedProject.count === 0) throw new StatusError(400, "The project to transfer was not provisioned by Neon or has already been transferred.");
+
+      const recentDbUser = await tx.projectUser.findUnique({
+        where: {
+          projectId_projectUserId: {
+            projectId: "internal",
+            projectUserId: user.id,
+          },
+        },
+      }) ?? throwErr("Authenticated user not found in transaction. Something went wrong. Did the user delete their account at the wrong time? (Very unlikely.)");
+      const rduServerMetadata: any = recentDbUser.serverMetadata;
+
+      await tx.projectUser.update({
+        where: {
+          projectId_projectUserId: {
+            projectId: "internal",
+            projectUserId: user.id,
+          },
+        },
+        data: {
+          serverMetadata: {
+            ...typeof rduServerMetadata === "object" ? rduServerMetadata : {},
+            managedProjectIds: [
+              ...(Array.isArray(rduServerMetadata?.managedProjectIds) ? rduServerMetadata.managedProjectIds : []),
+              data.project_id,
+            ],
+          },
+        },
+      });
+    });
+
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        project_id: data.project_id,
+      },
+    };
+  }
+});

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/initiate/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/initiate/route.tsx
@@ -2,9 +2,9 @@ import { getProject } from "@/lib/projects";
 import { prismaClient } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { neonAuthorizationHeaderSchema, urlSchema, yupNumber, yupObject, yupString, yupTuple } from "@stackframe/stack-shared/dist/schema-fields";
-import { decodeBase64 } from "@stackframe/stack-shared/dist/utils/bytes";
 import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { StatusError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+import { decodeBasicAuthorizationHeader } from "@stackframe/stack-shared/dist/utils/http";
 import { neonIntegrationProjectTransferCodeHandler } from "../confirm/verification-code-handler";
 
 export const POST = createSmartRouteHandler({
@@ -28,9 +28,7 @@ export const POST = createSmartRouteHandler({
   }),
   handler: async (req) => {
     const { authorization } = req.headers;
-    const encoded = authorization[0].split(' ')[1];
-    const decoded = new TextDecoder().decode(decodeBase64(encoded));
-    const clientId = decoded.split(':')[0];
+    const [clientId, clientSecret] = decodeBasicAuthorizationHeader(authorization[0])!;
     const internalProject = await getProject("internal") ?? throwErr("Internal project not found");
 
     const neonProvisionedProject = await prismaClient.neonProvisionedProject.findUnique({

--- a/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/initiate/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/projects/transfer/initiate/route.tsx
@@ -1,0 +1,65 @@
+import { getProject } from "@/lib/projects";
+import { prismaClient } from "@/prisma-client";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { neonAuthorizationHeaderSchema, urlSchema, yupNumber, yupObject, yupString, yupTuple } from "@stackframe/stack-shared/dist/schema-fields";
+import { decodeBase64 } from "@stackframe/stack-shared/dist/utils/bytes";
+import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
+import { StatusError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+import { neonIntegrationProjectTransferCodeHandler } from "../confirm/verification-code-handler";
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    hidden: true,
+  },
+  request: yupObject({
+    body: yupObject({
+      project_id: yupString().defined(),
+    }).defined(),
+    headers: yupObject({
+      authorization: yupTuple([neonAuthorizationHeaderSchema.defined()]).defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      confirmation_url: urlSchema.defined(),
+    }).defined(),
+  }),
+  handler: async (req) => {
+    const { authorization } = req.headers;
+    const encoded = authorization[0].split(' ')[1];
+    const decoded = new TextDecoder().decode(decodeBase64(encoded));
+    const clientId = decoded.split(':')[0];
+    const internalProject = await getProject("internal") ?? throwErr("Internal project not found");
+
+    const neonProvisionedProject = await prismaClient.neonProvisionedProject.findUnique({
+      where: {
+        projectId: req.body.project_id,
+        neonClientId: clientId,
+      },
+    });
+    if (!neonProvisionedProject) {
+      throw new StatusError(400, "This project either doesn't exist or the current Neon client is not authorized to transfer it. Note that projects can only be transferred once.");
+    }
+
+    const transferCodeObj = await neonIntegrationProjectTransferCodeHandler.createCode({
+      project: internalProject,
+      method: {},
+      data: {
+        project_id: neonProvisionedProject.projectId,
+        neon_client_id: neonProvisionedProject.neonClientId,
+      },
+      callbackUrl: new URL("/integrations/neon/projects/transfer/confirm", getEnvVariable("NEXT_PUBLIC_STACK_DASHBOARD_URL")),
+      expiresInMs: 1000 * 60 * 60,
+    });
+
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        confirmation_url: transferCodeObj.link.toString(),
+      },
+    };
+  },
+});

--- a/apps/backend/src/app/api/v1/internal/projects/crud.tsx
+++ b/apps/backend/src/app/api/v1/internal/projects/crud.tsx
@@ -1,14 +1,11 @@
-import { fullProjectInclude, listManagedProjectIds, projectPrismaToCrud } from "@/lib/projects";
-import { ensureSharedProvider, ensureStandardProvider } from "@/lib/request-checks";
+import { createProject, fullProjectInclude, listManagedProjectIds, projectPrismaToCrud } from "@/lib/projects";
 import { prismaClient } from "@/prisma-client";
 import { createCrudHandlers } from "@/route-handlers/crud-handler";
 import { KnownErrors } from "@stackframe/stack-shared";
 import { internalProjectsCrud } from "@stackframe/stack-shared/dist/interface/crud/projects";
 import { projectIdSchema, yupObject } from "@stackframe/stack-shared/dist/schema-fields";
-import { StackAssertionError, captureError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+import { throwErr } from "@stackframe/stack-shared/dist/utils/errors";
 import { createLazyProxy } from "@stackframe/stack-shared/dist/utils/proxies";
-import { typedToUppercase } from "@stackframe/stack-shared/dist/utils/strings";
-import { generateUuid } from "@stackframe/stack-shared/dist/utils/uuids";
 
 // if one of these users creates a project, the others will be added as owners
 const ownerPacks: Set<string>[] = [];
@@ -37,224 +34,13 @@ export const internalProjectsCrudHandlers = createLazyProxy(() => createCrudHand
     const ownerPack = ownerPacks.find(p => p.has(user.id));
     const userIds = ownerPack ? [...ownerPack] : [user.id];
 
-    const result = await prismaClient.$transaction(async (tx) => {
-      const project = await tx.project.create({
-        data: {
-          id: generateUuid(),
-          displayName: data.display_name,
-          description: data.description,
-          isProductionMode: data.is_production_mode ?? false,
-          config: {
-            create: {
-              signUpEnabled: data.config?.sign_up_enabled ?? (disableSignUpByDefault.has(user.id) ? false : true),
-              allowLocalhost: data.config?.allow_localhost ?? true,
-              createTeamOnSignUp: data.config?.create_team_on_sign_up ?? false,
-              clientTeamCreationEnabled: data.config?.client_team_creation_enabled ?? false,
-              clientUserDeletionEnabled: data.config?.client_user_deletion_enabled ?? false,
-              domains: data.config?.domains ? {
-                create: data.config.domains.map(item => ({
-                  domain: item.domain,
-                  handlerPath: item.handler_path,
-                }))
-              } : undefined,
-              oauthProviderConfigs: data.config?.oauth_providers ? {
-                create: data.config.oauth_providers.map(item => ({
-                  id: item.id,
-                  proxiedOAuthConfig: item.type === "shared" ? {
-                    create: {
-                      type: typedToUppercase(ensureSharedProvider(item.id)),
-                    }
-                  } : undefined,
-                  standardOAuthConfig: item.type === "standard" ? {
-                    create: {
-                      type: typedToUppercase(ensureStandardProvider(item.id)),
-                      clientId: item.client_id ?? throwErr('client_id is required'),
-                      clientSecret: item.client_secret ?? throwErr('client_secret is required'),
-                      facebookConfigId: item.facebook_config_id,
-                      microsoftTenantId: item.microsoft_tenant_id,
-                    }
-                  } : undefined,
-                }))
-              } : undefined,
-              emailServiceConfig: data.config?.email_config ? {
-                create: {
-                  proxiedEmailServiceConfig: data.config.email_config.type === "shared" ? {
-                    create: {}
-                  } : undefined,
-                  standardEmailServiceConfig: data.config.email_config.type === "standard" ? {
-                    create: {
-                      host: data.config.email_config.host ?? throwErr('host is required'),
-                      port: data.config.email_config.port ?? throwErr('port is required'),
-                      username: data.config.email_config.username ?? throwErr('username is required'),
-                      password: data.config.email_config.password ?? throwErr('password is required'),
-                      senderEmail: data.config.email_config.sender_email ?? throwErr('sender_email is required'),
-                      senderName: data.config.email_config.sender_name ?? throwErr('sender_name is required'),
-                    }
-                  } : undefined,
-                }
-              } : {
-                create: {
-                  proxiedEmailServiceConfig: {
-                    create: {}
-                  },
-                },
-              },
-            },
-          }
-        },
-        include: fullProjectInclude,
-      });
-
-      // all oauth providers are created as auth methods for backwards compatibility
-      await tx.projectConfig.update({
-        where: {
-          id: project.config.id,
-        },
-        data: {
-          authMethodConfigs: {
-            create: [
-              ...data.config?.oauth_providers ? project.config.oauthProviderConfigs.map(item => ({
-                enabled: (data.config?.oauth_providers?.find(p => p.id === item.id) ?? throwErr("oauth provider not found")).enabled,
-                oauthProviderConfig: {
-                  connect: {
-                    projectConfigId_id: {
-                      projectConfigId: project.config.id,
-                      id: item.id,
-                    }
-                  }
-                }
-              })) : [],
-              ...data.config?.magic_link_enabled ? [{
-                enabled: true,
-                otpConfig: {
-                  create: {
-                    contactChannelType: 'EMAIL',
-                  }
-                },
-              }] : [],
-              ...(data.config?.credential_enabled ?? true) ? [{
-                enabled: true,
-                passwordConfig: {
-                  create: {}
-                },
-              }] : [],
-              ...data.config?.passkey_enabled ? [{
-                enabled: true,
-                passkeyConfig: {
-                  create: {}
-                },
-              }] : [],
-            ]
-          }
-        }
-      });
-
-      // all standard oauth providers are created as connected accounts for backwards compatibility
-      await tx.projectConfig.update({
-        where: {
-          id: project.config.id,
-        },
-        data: {
-          connectedAccountConfigs: data.config?.oauth_providers ? {
-            create: project.config.oauthProviderConfigs.map(item => ({
-              enabled: (data.config?.oauth_providers?.find(p => p.id === item.id) ?? throwErr("oauth provider not found")).enabled,
-              oauthProviderConfig: {
-                connect: {
-                  projectConfigId_id: {
-                    projectConfigId: project.config.id,
-                    id: item.id,
-                  }
-                }
-              }
-            })),
-          } : undefined,
-        }
-      });
-
-      await tx.permission.create({
-        data: {
-          projectId: project.id,
-          projectConfigId: project.config.id,
-          queryableId: "member",
-          description: "Default permission for team members",
-          scope: 'TEAM',
-          parentEdges: {
-            createMany: {
-              data: (['READ_MEMBERS', 'INVITE_MEMBERS'] as const).map(p => ({ parentTeamSystemPermission: p })),
-            },
-          },
-          isDefaultTeamMemberPermission: true,
-        },
-      });
-
-      await tx.permission.create({
-        data: {
-          projectId: project.id,
-          projectConfigId: project.config.id,
-          queryableId: "admin",
-          description: "Default permission for team creators",
-          scope: 'TEAM',
-          parentEdges: {
-            createMany: {
-              data: (['UPDATE_TEAM', 'DELETE_TEAM', 'READ_MEMBERS', 'REMOVE_MEMBERS', 'INVITE_MEMBERS'] as const).map(p =>({ parentTeamSystemPermission: p }))
-            },
-          },
-          isDefaultTeamCreatorPermission: true,
-        },
-      });
-
-      // Update owner metadata
-      for (const userId of userIds) {
-        const projectUserTx = await tx.projectUser.findUnique({
-          where: {
-            projectId_projectUserId: {
-              projectId: "internal",
-              projectUserId: userId,
-            },
-          },
-        });
-        if (!projectUserTx) {
-          if (userId === user.id) {
-            throw new StackAssertionError(`User with id '${userId}' not found after creation`, { user });
-          } else {
-            captureError("project-creation-owner-packs", new StackAssertionError(`User ${userId} in owner pack not found. The user that created this project is in an owner pack, but no user with that ID was found. Did they delete their account? Continuing silently, but you should probably update the owner pack.`, { userId, creator: user }));
-            continue;
-          }
-        }
-
-        const serverMetadataTx: any = projectUserTx.serverMetadata ?? {};
-
-        await tx.projectUser.update({
-          where: {
-            projectId_projectUserId: {
-              projectId: "internal",
-              projectUserId: projectUserTx.projectUserId,
-            },
-          },
-          data: {
-            serverMetadata: {
-              ...serverMetadataTx ?? {},
-              managedProjectIds: [
-                ...serverMetadataTx?.managedProjectIds ?? [],
-                project.id,
-              ],
-            },
-          },
-        });
-      }
-
-      const result = await tx.project.findUnique({
-        where: { id: project.id },
-        include: fullProjectInclude,
-      });
-
-      if (!result) {
-        throw new StackAssertionError(`Project with id '${project.id}' not found after creation`, { project });
-      }
-      return result;
+    return await createProject(userIds, {
+      ...data,
+      config: {
+        ...data.config,
+        sign_up_enabled: data.config?.sign_up_enabled ?? (disableSignUpByDefault.has(user.id) ? false : true),
+      },
     });
-
-    return projectPrismaToCrud(result);
   },
   onList: async ({ auth }) => {
     const results = await prismaClient.project.findMany({

--- a/apps/backend/src/lib/projects.tsx
+++ b/apps/backend/src/lib/projects.tsx
@@ -1,10 +1,12 @@
 import { prismaClient } from "@/prisma-client";
 import { Prisma } from "@prisma/client";
-import { ProjectsCrud } from "@stackframe/stack-shared/dist/interface/crud/projects";
+import { InternalProjectsCrud, ProjectsCrud } from "@stackframe/stack-shared/dist/interface/crud/projects";
 import { UsersCrud } from "@stackframe/stack-shared/dist/interface/crud/users";
-import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
-import { typedToLowercase } from "@stackframe/stack-shared/dist/utils/strings";
+import { StackAssertionError, captureError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+import { typedToLowercase, typedToUppercase } from "@stackframe/stack-shared/dist/utils/strings";
+import { generateUuid } from "@stackframe/stack-shared/dist/utils/uuids";
 import { fullPermissionInclude, teamPermissionDefinitionJsonFromDbType, teamPermissionDefinitionJsonFromTeamSystemDbType } from "./permissions";
+import { ensureSharedProvider, ensureStandardProvider } from "./request-checks";
 
 export const fullProjectInclude = {
   config: {
@@ -202,4 +204,221 @@ export async function getProject(projectId: string): Promise<ProjectsCrud["Admin
   }
 
   return projectPrismaToCrud(rawProject);
+}
+
+export async function createProject(ownerIds: string[], data: InternalProjectsCrud["Admin"]["Create"]) {
+  const result = await prismaClient.$transaction(async (tx) => {
+    const project = await tx.project.create({
+      data: {
+        id: generateUuid(),
+        displayName: data.display_name,
+        description: data.description,
+        isProductionMode: data.is_production_mode ?? false,
+        config: {
+          create: {
+            signUpEnabled: data.config?.sign_up_enabled,
+            allowLocalhost: data.config?.allow_localhost ?? true,
+            createTeamOnSignUp: data.config?.create_team_on_sign_up ?? false,
+            clientTeamCreationEnabled: data.config?.client_team_creation_enabled ?? false,
+            clientUserDeletionEnabled: data.config?.client_user_deletion_enabled ?? false,
+            domains: data.config?.domains ? {
+              create: data.config.domains.map(item => ({
+                domain: item.domain,
+                handlerPath: item.handler_path,
+              }))
+            } : undefined,
+            oauthProviderConfigs: data.config?.oauth_providers ? {
+              create: data.config.oauth_providers.map(item => ({
+                id: item.id,
+                proxiedOAuthConfig: item.type === "shared" ? {
+                  create: {
+                    type: typedToUppercase(ensureSharedProvider(item.id)),
+                  }
+                } : undefined,
+                standardOAuthConfig: item.type === "standard" ? {
+                  create: {
+                    type: typedToUppercase(ensureStandardProvider(item.id)),
+                    clientId: item.client_id ?? throwErr('client_id is required'),
+                    clientSecret: item.client_secret ?? throwErr('client_secret is required'),
+                    facebookConfigId: item.facebook_config_id,
+                    microsoftTenantId: item.microsoft_tenant_id,
+                  }
+                } : undefined,
+              }))
+            } : undefined,
+            emailServiceConfig: data.config?.email_config ? {
+              create: {
+                proxiedEmailServiceConfig: data.config.email_config.type === "shared" ? {
+                  create: {}
+                } : undefined,
+                standardEmailServiceConfig: data.config.email_config.type === "standard" ? {
+                  create: {
+                    host: data.config.email_config.host ?? throwErr('host is required'),
+                    port: data.config.email_config.port ?? throwErr('port is required'),
+                    username: data.config.email_config.username ?? throwErr('username is required'),
+                    password: data.config.email_config.password ?? throwErr('password is required'),
+                    senderEmail: data.config.email_config.sender_email ?? throwErr('sender_email is required'),
+                    senderName: data.config.email_config.sender_name ?? throwErr('sender_name is required'),
+                  }
+                } : undefined,
+              }
+            } : {
+              create: {
+                proxiedEmailServiceConfig: {
+                  create: {}
+                },
+              },
+            },
+          },
+        }
+      },
+      include: fullProjectInclude,
+    });
+
+    // all oauth providers are created as auth methods for backwards compatibility
+    await tx.projectConfig.update({
+      where: {
+        id: project.config.id,
+      },
+      data: {
+        authMethodConfigs: {
+          create: [
+            ...data.config?.oauth_providers ? project.config.oauthProviderConfigs.map(item => ({
+              enabled: (data.config?.oauth_providers?.find(p => p.id === item.id) ?? throwErr("oauth provider not found")).enabled,
+              oauthProviderConfig: {
+                connect: {
+                  projectConfigId_id: {
+                    projectConfigId: project.config.id,
+                    id: item.id,
+                  }
+                }
+              }
+            })) : [],
+            ...data.config?.magic_link_enabled ? [{
+              enabled: true,
+              otpConfig: {
+                create: {
+                  contactChannelType: 'EMAIL',
+                }
+              },
+            }] : [],
+            ...(data.config?.credential_enabled ?? true) ? [{
+              enabled: true,
+              passwordConfig: {
+                create: {}
+              },
+            }] : [],
+            ...data.config?.passkey_enabled ? [{
+              enabled: true,
+              passkeyConfig: {
+                create: {}
+              },
+            }] : [],
+          ]
+        }
+      }
+    });
+
+    // all standard oauth providers are created as connected accounts for backwards compatibility
+    await tx.projectConfig.update({
+      where: {
+        id: project.config.id,
+      },
+      data: {
+        connectedAccountConfigs: data.config?.oauth_providers ? {
+          create: project.config.oauthProviderConfigs.map(item => ({
+            enabled: (data.config?.oauth_providers?.find(p => p.id === item.id) ?? throwErr("oauth provider not found")).enabled,
+            oauthProviderConfig: {
+              connect: {
+                projectConfigId_id: {
+                  projectConfigId: project.config.id,
+                  id: item.id,
+                }
+              }
+            }
+          })),
+        } : undefined,
+      }
+    });
+
+    await tx.permission.create({
+      data: {
+        projectId: project.id,
+        projectConfigId: project.config.id,
+        queryableId: "member",
+        description: "Default permission for team members",
+        scope: 'TEAM',
+        parentEdges: {
+          createMany: {
+            data: (['READ_MEMBERS', 'INVITE_MEMBERS'] as const).map(p => ({ parentTeamSystemPermission: p })),
+          },
+        },
+        isDefaultTeamMemberPermission: true,
+      },
+    });
+
+    await tx.permission.create({
+      data: {
+        projectId: project.id,
+        projectConfigId: project.config.id,
+        queryableId: "admin",
+        description: "Default permission for team creators",
+        scope: 'TEAM',
+        parentEdges: {
+          createMany: {
+            data: (['UPDATE_TEAM', 'DELETE_TEAM', 'READ_MEMBERS', 'REMOVE_MEMBERS', 'INVITE_MEMBERS'] as const).map(p =>({ parentTeamSystemPermission: p }))
+          },
+        },
+        isDefaultTeamCreatorPermission: true,
+      },
+    });
+
+    // Update owner metadata
+    for (const userId of ownerIds) {
+      const projectUserTx = await tx.projectUser.findUnique({
+        where: {
+          projectId_projectUserId: {
+            projectId: "internal",
+            projectUserId: userId,
+          },
+        },
+      });
+      if (!projectUserTx) {
+        captureError("project-creation-owner-not-found", new StackAssertionError(`Attempted to create project, but owner user ID ${userId} not found. Did they delete their account? Continuing silently, but if the user is coming from an owner pack you should probably update it.`, { ownerIds }));
+        continue;
+      }
+
+      const serverMetadataTx: any = projectUserTx.serverMetadata ?? {};
+
+      await tx.projectUser.update({
+        where: {
+          projectId_projectUserId: {
+            projectId: "internal",
+            projectUserId: projectUserTx.projectUserId,
+          },
+        },
+        data: {
+          serverMetadata: {
+            ...serverMetadataTx ?? {},
+            managedProjectIds: [
+              ...serverMetadataTx?.managedProjectIds ?? [],
+              project.id,
+            ],
+          },
+        },
+      });
+    }
+
+    const result = await tx.project.findUnique({
+      where: { id: project.id },
+      include: fullProjectInclude,
+    });
+
+    if (!result) {
+      throw new StackAssertionError(`Project with id '${project.id}' not found after creation`, { project });
+    }
+    return result;
+  });
+
+  return projectPrismaToCrud(result);
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/users/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/users/page-client.tsx
@@ -27,6 +27,7 @@ export default function PageClient() {
           Congratulations on starting your project! Check the <StyledLink href="https://docs.stack-auth.com">documentation</StyledLink> to add your first users.
         </Alert>
       )}
+
       <UserTable />
     </PageLayout>
   );

--- a/apps/dashboard/src/app/(main)/integrations/neon/confirm/neon-confirm-card.tsx
+++ b/apps/dashboard/src/app/(main)/integrations/neon/confirm/neon-confirm-card.tsx
@@ -18,7 +18,7 @@ export default function NeonConfirmCard(props: { onContinue: (options: { project
 
 
   return (
-    <Card className="max-w-lg">
+    <Card className="max-w-lg text-center">
       <CardHeader className="flex-row items-end justify-center gap-4">
         <Image src={NeonLogo} alt="Neon" width={55} />
         <div className="relative self-center w-10 hidden dark:block">

--- a/apps/dashboard/src/app/(main)/integrations/neon/confirm/page.tsx
+++ b/apps/dashboard/src/app/(main)/integrations/neon/confirm/page.tsx
@@ -55,23 +55,7 @@ export default async function NeonIntegrationConfirmPage(props: { searchParams: 
 
   return (
     <>
-      <style>
-        {`
-          body {
-            background-image: linear-gradient(45deg, #000, #444, #000, #444, #000, #444, #000);
-            background-size: 400% 400%;
-            background-repeat: no-repeat;
-            animation: celebrate-gradient 60s linear infinite;
-          }
-          @keyframes celebrate-gradient {
-            0% { background-position: 0% 100%; }
-            100% { background-position: 100% 0%; }
-          }
-        `}
-      </style>
-      <div className="flex items-center justify-center min-h-screen text-center">
-        <NeonConfirmCard onContinue={onContinue} />
-      </div>
+      <NeonConfirmCard onContinue={onContinue} />
     </>
   );
 }

--- a/apps/dashboard/src/app/(main)/integrations/neon/layout.tsx
+++ b/apps/dashboard/src/app/(main)/integrations/neon/layout.tsx
@@ -1,0 +1,29 @@
+
+export const metadata = {
+  title: "Neon x Stack Auth",
+};
+
+export default async function NeonIntegrationConfirmPage(props: { children: React.ReactNode }) {
+  return (
+    <>
+      <style>
+        {`
+          body {
+            color: white;
+            background-image: linear-gradient(45deg, #000, #444, #000, #444, #000, #444, #000);
+            background-size: 400% 400%;
+            background-repeat: no-repeat;
+            animation: celebrate-gradient 60s linear infinite;
+          }
+          @keyframes celebrate-gradient {
+            0% { background-position: 0% 100%; }
+            100% { background-position: 100% 0%; }
+          }
+        `}
+      </style>
+      <div className="flex items-center justify-center min-h-screen">
+        {props.children}
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/src/app/(main)/integrations/neon/projects/transfer/confirm/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/integrations/neon/projects/transfer/confirm/page-client.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { Logo } from "@/components/logo";
+import { useStackApp, useUser } from "@stackframe/stack";
+import { wait } from "@stackframe/stack-shared/dist/utils/promises";
+import { Button, Card, CardContent, CardFooter, CardHeader, Input, Typography } from "@stackframe/stack-ui";
+import Image from "next/image";
+import { useRouter, useSearchParams } from "next/navigation";
+import NeonLogo from "../../../../../../../../public/neon.png";
+
+export const stackAppInternalsSymbol = Symbol.for("StackAuth--DO-NOT-USE-OR-YOU-WILL-BE-FIRED--StackAppInternals");
+
+export default function NeonIntegrationProjectTransferConfirmPageClient() {
+  const app = useStackApp();
+  const user = useUser({ projectIdMustMatch: "internal" });
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentUrl = new URL(window.location.href);
+  const signUpSearchParams = new URLSearchParams();
+  signUpSearchParams.set("after_auth_return_to", currentUrl.pathname + currentUrl.search + currentUrl.hash);
+  const signUpUrl = `/handler/signup?${signUpSearchParams.toString()}`;
+
+  return (
+    <Card className="max-w-lg text-center">
+      <CardHeader className="flex-row items-end justify-center gap-4">
+        <Image src={NeonLogo} alt="Neon" width={55} />
+        <div className="relative self-center w-10 hidden dark:block">
+          <div style={{
+            position: "absolute",
+            width: 40,
+            height: 6,
+            backgroundImage: "repeating-linear-gradient(135deg, #00ff00, #ffffff)",
+            transform: "rotate(-45deg)",
+          }} />
+          <div style={{
+            position: "absolute",
+            width: 40,
+            height: 6,
+            backgroundImage: "repeating-linear-gradient(45deg, #00ff00, #ffffff)",
+            transform: "rotate(45deg)",
+          }} />
+        </div>
+        <div className="relative self-center w-10 block dark:hidden">
+          <div style={{
+            position: "absolute",
+            width: 40,
+            height: 6,
+            backgroundImage: "repeating-linear-gradient(135deg, #00ff00, #000000)",
+            transform: "rotate(-45deg)",
+          }} />
+          <div style={{
+            position: "absolute",
+            width: 40,
+            height: 6,
+            backgroundImage: "repeating-linear-gradient(45deg, #00ff00, #000000)",
+            transform: "rotate(45deg)",
+          }} />
+        </div>
+        <Logo noLink alt="Stack" width={50} />
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <h1 className="text-3xl font-semibold">
+          Project transfer
+        </h1>
+        <Typography className="text-sm">
+          Neon would like to transfer a Stack Auth project and link it to your own account. This will let you access the project from Stack Auth&apos;s dashboard.
+        </Typography>
+        {user ? (
+          <>
+            <Typography className="mb-3 text-sm">
+              Which Stack Auth account would you like to transfer the project to? (This is <span className="font-semibold text-red-500">irreversible</span>.)
+            </Typography>
+            <Input type="text" disabled prefixItem={<Logo noLink width={15} height={15} />} value={`Signed in as ${user.primaryEmail || user.displayName || "Unnamed user"}`} />
+            <Button variant="secondary" onClick={async () => await user.signOut({ redirectUrl: signUpUrl })}>
+              Switch account
+            </Button>
+          </>
+        ) : (
+          <Typography className="text-sm">
+            To continue, please sign in or create a Stack Auth account.
+          </Typography>
+        )}
+
+      </CardContent>
+      <CardFooter className="flex justify-end mt-4">
+        <div className="flex gap-2 justify-center">
+          <Button variant="secondary" onClick={() => { window.close(); }}>
+            Cancel
+          </Button>
+          <Button onClick={async () => {
+            if (user) {
+              const confirmRes = await (app as any)[stackAppInternalsSymbol].sendRequest("/integrations/neon/projects/transfer/confirm", {
+                method: "POST",
+                body: JSON.stringify({
+                  code: searchParams.get("code"),
+                }),
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              });
+              const confirmResJson = await confirmRes.json();
+              router.push(`/projects/${confirmResJson.project_id}`);
+              await wait(3000);
+            } else {
+              router.push(signUpUrl);
+              await wait(3000);
+            }
+          }}>
+            {user ? "Transfer" : "Sign in"}
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/dashboard/src/app/(main)/integrations/neon/projects/transfer/confirm/page.tsx
+++ b/apps/dashboard/src/app/(main)/integrations/neon/projects/transfer/confirm/page.tsx
@@ -1,0 +1,20 @@
+import NeonIntegrationProjectTransferConfirmPageClient from "./page-client";
+
+export const metadata = {
+  title: "Project transfer",
+};
+
+export default async function NeonIntegrationProjectTransferConfirmPage(props: { searchParams: { code?: string } }) {
+  const transferCode = props.searchParams.code;
+  if (!transferCode) {
+    return <>
+      <div>Error: No transfer code provided.</div>
+    </>;
+  }
+
+  return (
+    <>
+      <NeonIntegrationProjectTransferConfirmPageClient />
+    </>
+  );
+}

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/authorize.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/authorize.test.ts
@@ -75,8 +75,8 @@ it("should fail if an invalid redirect URL is provided", async ({ expect }) => {
       "status": 400,
       "body": {
         "code": "SCHEMA_ERROR",
-        "details": { "message": "Request validation failed on GET /api/v1/auth/oauth/authorize/spotify:\\n  - Invalid URL" },
-        "error": "Request validation failed on GET /api/v1/auth/oauth/authorize/spotify:\\n  - Invalid URL",
+        "details": { "message": "Request validation failed on GET /api/v1/auth/oauth/authorize/spotify:\\n  - query.redirect_uri is not a valid URL" },
+        "error": "Request validation failed on GET /api/v1/auth/oauth/authorize/spotify:\\n  - query.redirect_uri is not a valid URL",
       },
       "headers": Headers {
         "x-stack-known-error": "SCHEMA_ERROR",

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/provision.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/provision.test.ts
@@ -1,0 +1,78 @@
+import { it } from "../../../../../../../helpers";
+import { niceBackendFetch } from "../../../../../../backend-helpers";
+
+export async function provisionProject() {
+  return await niceBackendFetch("/api/v1/integrations/neon/projects/provision", {
+    method: "POST",
+    body: {
+      display_name: "Test project",
+    },
+    headers: {
+      "Authorization": "Basic bmVvbi1sb2NhbDpuZW9uLWxvY2FsLXNlY3JldA==",
+    },
+  });
+}
+
+it("should be able to provision a new project if neon client details are correct", async ({ expect }) => {
+  const response = await provisionProject();
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": {
+        "project_id": "<stripped UUID>",
+        "super_secret_admin_key": <stripped field 'super_secret_admin_key'>,
+      },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});
+
+it("should fail if the neon client details are incorrect", async ({ expect }) => {
+  const response = await niceBackendFetch("/api/v1/integrations/neon/projects/provision", {
+    method: "POST",
+    body: {
+      display_name: "Test project",
+    },
+    headers: {
+      "Authorization": "Basic bmVvbi1sb2NhbDpuZW9uLWxvY2FsLXMlY3JldA==",
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": {
+        "code": "SCHEMA_ERROR",
+        "details": { "message": "Request validation failed on POST /api/v1/integrations/neon/projects/provision:\\n  - Invalid client_id:client_secret values; did you use the correct values for the Neon integration?" },
+        "error": "Request validation failed on POST /api/v1/integrations/neon/projects/provision:\\n  - Invalid client_id:client_secret values; did you use the correct values for the Neon integration?",
+      },
+      "headers": Headers {
+        "x-stack-known-error": "SCHEMA_ERROR",
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+});
+
+
+it("should fail if the neon client details are missing", async ({ expect }) => {
+  const response = await niceBackendFetch("/api/v1/integrations/neon/projects/provision", {
+    method: "POST",
+    body: {
+      display_name: "Test project",
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": {
+        "code": "SCHEMA_ERROR",
+        "details": { "message": "Request validation failed on POST /api/v1/integrations/neon/projects/provision:\\n  - headers.authorization must be defined" },
+        "error": "Request validation failed on POST /api/v1/integrations/neon/projects/provision:\\n  - headers.authorization must be defined",
+      },
+      "headers": Headers {
+        "x-stack-known-error": "SCHEMA_ERROR",
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+});

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts
@@ -1,0 +1,136 @@
+import { expect } from "vitest";
+import { it } from "../../../../../../../helpers";
+import { Auth, Project, niceBackendFetch } from "../../../../../../backend-helpers";
+import { provisionProject } from "./provision.test";
+
+async function initiateTransfer(projectId: string) {
+  const response = await niceBackendFetch("/api/v1/integrations/neon/projects/transfer/initiate", {
+    method: "POST",
+    body: {
+      project_id: projectId,
+    },
+    headers: {
+      "Authorization": "Basic bmVvbi1sb2NhbDpuZW9uLWxvY2FsLXNlY3JldA==",
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": { "confirmation_url": "http://localhost:8101/integrations/neon/projects/transfer/confirm?code=%3Cstripped+query+param%3E" },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+  const confirmationUrl = new URL(response.body.confirmation_url);
+  const code = confirmationUrl.searchParams.get("code")!;
+  return { code };
+}
+
+it("should be able to transfer a project exactly once", async ({ expect }) => {
+  const provisioned = await provisionProject();
+  const projectId = provisioned.body.project_id;
+  const { code } = await initiateTransfer(projectId);
+  await Auth.Otp.signIn();
+  const response = await niceBackendFetch(`/api/v1/integrations/neon/projects/transfer/confirm`, {
+    method: "POST",
+    accessType: "client",
+    body: {
+      code,
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": { "project_id": "<stripped UUID>" },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+  expect(response.body.project_id).toBe(projectId);
+
+  // but only once!
+  const response2 = await niceBackendFetch("/api/v1/integrations/neon/projects/transfer/initiate", {
+    method: "POST",
+    body: {
+      project_id: projectId,
+    },
+    headers: {
+      "Authorization": "Basic bmVvbi1sb2NhbDpuZW9uLWxvY2FsLXNlY3JldA==",
+    },
+  });
+  expect(response2).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": "This project either doesn't exist or the current Neon client is not authorized to transfer it. Note that projects can only be transferred once.",
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});
+
+it("should fail if the project to transfer was not provisioned by Neon", async ({ expect }) => {
+  await Auth.Otp.signIn();
+  const createdProject = await Project.create();
+  const response = await niceBackendFetch("/api/v1/integrations/neon/projects/transfer/initiate", {
+    method: "POST",
+    body: {
+      project_id: createdProject.createProjectResponse.body.id,
+    },
+    headers: {
+      "Authorization": "Basic bmVvbi1sb2NhbDpuZW9uLWxvY2FsLXNlY3JldA==",
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": "This project either doesn't exist or the current Neon client is not authorized to transfer it. Note that projects can only be transferred once.",
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});
+
+it("should fail if the neon client details are missing", async ({ expect }) => {
+  const provisioned = await provisionProject();
+  const response = await niceBackendFetch("/api/v1/integrations/neon/projects/transfer/initiate", {
+    method: "POST",
+    body: {
+      project_id: provisioned.body.project_id,
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": {
+        "code": "SCHEMA_ERROR",
+        "details": { "message": "Request validation failed on POST /api/v1/integrations/neon/projects/transfer/initiate:\\n  - headers.authorization must be defined" },
+        "error": "Request validation failed on POST /api/v1/integrations/neon/projects/transfer/initiate:\\n  - headers.authorization must be defined",
+      },
+      "headers": Headers {
+        "x-stack-known-error": "SCHEMA_ERROR",
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+});
+
+it("should fail to transfer project if the user is not signed in", async ({ expect }) => {
+  const provisioned = await provisionProject();
+  const projectId = provisioned.body.project_id;
+  const { code } = await initiateTransfer(projectId);
+  const response = await niceBackendFetch(`/api/v1/integrations/neon/projects/transfer/confirm`, {
+    method: "POST",
+    body: {
+      code,
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": {
+        "code": "ACCESS_TYPE_REQUIRED",
+        "error": "You must specify an access level for this Stack project. Make sure project API keys are provided (eg. x-stack-publishable-client-key) and you set the x-stack-access-type header to 'client', 'server', or 'admin'.\\n\\nFor more information, see the docs on REST API authentication: https://docs.stack-auth.com/rest-api/auth#authentication",
+      },
+      "headers": Headers {
+        "x-stack-known-error": "ACCESS_TYPE_REQUIRED",
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+});

--- a/docs/fern/docs/pages/getting-started/users.mdx
+++ b/docs/fern/docs/pages/getting-started/users.mdx
@@ -181,7 +181,7 @@ Stack automatically creates a user profile on sign-up. Let's build a page that d
           {user ? (
             <div>
               <UserButton />
-              <p>Welcome, {user.displayName ?? "anonymous user"}</p>
+              <p>Welcome, {user.displayName ?? "unnamed user"}</p>
               <p>Your e-mail: {user.primaryEmail}</p>
               <button onClick={() => user.signOut()}>Sign Out</button>
             </div>
@@ -210,7 +210,7 @@ Stack automatically creates a user profile on sign-up. Let's build a page that d
           {user ? (
             <div>
               <UserButton />
-              <p>Welcome, {user.displayName ?? "anonymous user"}</p>
+              <p>Welcome, {user.displayName ?? "unnamed user"}</p>
               <p>Your e-mail: {user.primaryEmail}</p>
               <p><a href={stackServerApp.urls.signOut}>Sign Out</a></p>
             </div>

--- a/docs/fern/docs/pages/sdk/types/user.mdx
+++ b/docs/fern/docs/pages/sdk/types/user.mdx
@@ -39,7 +39,7 @@ type CurrentUser = {
   updatePassword(data): Promise<void>; //$stack-link-to:#currentuserupdatepassworddata
   getAuthHeaders(): Promise<Record<string, string>>; //$stack-link-to:#currentusergetauthheaders
   getAuthJson(): Promise<{ accessToken: string | null }>; //$stack-link-to:#currentusergetauthjson
-  signOut(): Promise<void>; //$stack-link-to:#currentusersignout
+  signOut([options]): Promise<void>; //$stack-link-to:#currentusersignoutoptions
   delete(): Promise<void>; //$stack-link-to:#currentuserdelete
 
   getTeam(id): Promise<Team | null>; //$stack-link-to:#currentusergetteamid
@@ -1143,7 +1143,7 @@ function handleRequest(data) {
 <Markdown src="../../snippets/divider.mdx" />
 
 
-## `currentUser.signOut()`
+## `currentUser.signOut(options)`
 </div><div className="stack-content">
 
 Signs out the user and clears the session.
@@ -1151,7 +1151,14 @@ Signs out the user and clears the session.
 ### Parameters
 
 <div className="indented">
-  No parameters.
+  <ParamField path="options" type="object">
+    An object containing multiple properties.
+    <Accordion title={<span className="accordion-show-properties" />}>
+      <ParamField path="redirectUrl" type="string">
+        The URL to redirect to after signing out. Defaults to the `afterSignOut` URL from the Stack app's `urls` object.
+      </ParamField>
+    </Accordion>
+  </ParamField>
 </div>
 
 ### Returns
@@ -1164,7 +1171,7 @@ Signs out the user and clears the session.
 ### Signature
 
 ```typescript
-declare function signOut(): Promise<void>;
+declare function signOut(options?: { redirectUrl?: string }): Promise<void>;
 ```
 
 ### Examples

--- a/eslint-configs/defaults.js
+++ b/eslint-configs/defaults.js
@@ -71,7 +71,7 @@ module.exports = {
       },
       {
         selector:
-          "MemberExpression:has(Identifier[name='yup']) Identifier[name='url']",
+          "MemberExpression:has(Identifier[name='yupString']) Identifier[name='url']",
         message:
           "Use urlSchema from schema-fields.tsx instead of yupString().url().",
       },

--- a/examples/supabase/.env.development
+++ b/examples/supabase/.env.development
@@ -2,6 +2,9 @@ NEXT_PUBLIC_SUPABASE_URL=supabase-project-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=supabase-anon-key
 SUPABASE_JWT_SECRET=supabase-jwt-secret
 
-NEXT_PUBLIC_STACK_PROJECT_ID=project-id-from-stack-dashboard
-NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=publishable-client-key-from-stack-dashboard
-STACK_SECRET_SERVER_KEY=secret-server-key-from-stack-dashboard
+# Contains the credentials for the internal project of Stack's default development environment setup.
+# Do not use in a production environment, instead replace it with actual values gathered from https://app.stack-auth.com.
+NEXT_PUBLIC_STACK_API_URL=http://localhost:8102
+NEXT_PUBLIC_STACK_PROJECT_ID=internal
+NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=this-publishable-client-key-is-for-local-development-only
+STACK_SECRET_SERVER_KEY=this-secret-server-key-is-for-local-development-only

--- a/packages/stack-shared/src/interface/clientInterface.ts
+++ b/packages/stack-shared/src/interface/clientInterface.ts
@@ -118,7 +118,7 @@ export class StackClientInterface {
       if (globalVar.navigator && !globalVar.navigator.onLine) {
         throw new Error("Failed to send Stack network request. It seems like you are offline. (window.navigator.onLine is falsy)", { cause: retriedResult.error });
       }
-      throw this._createNetworkError(retriedResult.error, session, requestType);
+      throw await this._createNetworkError(retriedResult.error, session, requestType);
     }
     return retriedResult.data;
   }
@@ -179,7 +179,7 @@ export class StackClientInterface {
     return new AccessToken(result.access_token);
   }
 
-  protected async sendClientRequest(
+  public async sendClientRequest(
     path: string,
     requestOptions: RequestInit,
     session: InternalSession | null,

--- a/packages/stack-shared/src/schema-fields.ts
+++ b/packages/stack-shared/src/schema-fields.ts
@@ -1,9 +1,10 @@
 import * as yup from "yup";
 import { KnownErrors } from ".";
-import { isBase64 } from "./utils/bytes";
+import { decodeBase64, isBase64 } from "./utils/bytes";
 import { StackAssertionError } from "./utils/errors";
 import { allProviders } from "./utils/oauth";
 import { deepPlainClone, omit } from "./utils/objects";
+import { isValidUrl } from "./utils/urls";
 import { isUuid } from "./utils/uuids";
 
 declare module "yup" {
@@ -183,16 +184,8 @@ export const adaptSchema = yupMixed<StackAdaptSentinel>();
  */
 export const urlSchema = yupString().test({
   name: 'url',
-  message: 'Invalid URL',
-  test: (value) => {
-    if (!value) return true;
-    try {
-      new URL(value);
-      return true;
-    } catch {
-      return false;
-    }
-  },
+  message: (params) => `${params.path} is not a valid URL`,
+  test: (value) => value == null || isValidUrl(value)
 });
 export const jsonSchema = yupMixed().nullable().defined().transform((value) => JSON.parse(JSON.stringify(value)));
 export const jsonStringSchema = yupString().test("json", (params) => `${params.path} is not valid JSON`, (value) => {
@@ -378,6 +371,28 @@ export const contactChannelValueSchema = yupString().when('type', {
 export const contactChannelUsedForAuthSchema = yupBoolean().meta({ openapiField: { description: 'Whether the contact channel is used for authentication. If this is set to `true`, the user will be able to sign in with the contact channel with password or OTP.', exampleValue: true } });
 export const contactChannelIsVerifiedSchema = yupBoolean().meta({ openapiField: { description: 'Whether the contact channel has been verified. If this is set to `true`, the contact channel has been verified to belong to the user.', exampleValue: true } });
 export const contactChannelIsPrimarySchema = yupBoolean().meta({ openapiField: { description: 'Whether the contact channel is the primary contact channel. If this is set to `true`, it will be used for authentication and notifications by default.', exampleValue: true } });
+
+// Headers
+export const basicAuthorizationHeaderSchema = yupString().test('is-basic-authorization-header', 'Authorization header must be in the format "Basic <base64>"', (value) => {
+  if (!value) return true;
+  const [type, encoded, ...rest] = value.split(' ');
+  if (rest.length > 0) return false;
+  if (!encoded) return false;
+  if (type !== 'Basic') return false;
+  if (!isBase64(encoded)) return false;
+  const decoded = new TextDecoder().decode(decodeBase64(encoded));
+  return decoded.includes(':');
+});
+
+// Neon integration
+export const neonAuthorizationHeaderSchema = basicAuthorizationHeaderSchema.test('is-neon-authorization-header', 'Invalid client_id:client_secret values; did you use the correct values for the Neon integration?', (value) => {
+  if (!value) return true;
+  const decoded = new TextDecoder().decode(decodeBase64(value.split(' ')[1]));
+  for (const neonClientConfig of JSON.parse(process.env.STACK_NEON_INTEGRATION_CLIENTS_CONFIG || '[]')) {
+    if (decoded === `${neonClientConfig.client_id}:${neonClientConfig.client_secret}`) return true;
+  }
+  return false;
+});
 
 // Utils
 export function yupDefinedWhen<S extends yup.AnyObject>(

--- a/packages/stack-shared/src/utils/http.tsx
+++ b/packages/stack-shared/src/utils/http.tsx
@@ -1,3 +1,5 @@
+import { decodeBase64, encodeBase64, isBase64 } from "./bytes";
+
 export const HTTP_METHODS = {
   "GET": {
     safe: true,
@@ -37,3 +39,19 @@ export const HTTP_METHODS = {
   },
 } as const;
 export type HttpMethod = keyof typeof HTTP_METHODS;
+
+export function decodeBasicAuthorizationHeader(value: string): [string, string] | null {
+  const [type, encoded, ...rest] = value.split(' ');
+  if (rest.length > 0) return null;
+  if (!encoded) return null;
+  if (type !== 'Basic') return null;
+  if (!isBase64(encoded)) return null;
+  const decoded = new TextDecoder().decode(decodeBase64(encoded));
+  const split = decoded.split(':');
+  return [split[0], split.slice(1).join(':')];
+}
+
+export function encodeBasicAuthorizationHeader(id: string, password: string): string {
+  if (id.includes(':')) throw new Error("Basic authorization header id cannot contain ':'");
+  return `Basic ${encodeBase64(new TextEncoder().encode(`${id}:${password}`))}`;
+}

--- a/packages/stack-shared/src/utils/urls.tsx
+++ b/packages/stack-shared/src/utils/urls.tsx
@@ -8,6 +8,10 @@ export function createUrlIfValid(...args: ConstructorParameters<typeof URL>) {
   }
 }
 
+export function isValidUrl(url: string) {
+  return !!createUrlIfValid(url);
+}
+
 export function isLocalhost(urlOrString: string | URL) {
   const url = createUrlIfValid(urlOrString);
   if (!url) return false;

--- a/packages/stack/src/components-page/stack-handler.tsx
+++ b/packages/stack/src/components-page/stack-handler.tsx
@@ -1,3 +1,4 @@
+import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
 import { FilterUndefined, filterUndefined, pick } from "@stackframe/stack-shared/dist/utils/objects";
 import { getRelativePart } from "@stackframe/stack-shared/dist/utils/urls";
 import { RedirectType, notFound, redirect } from 'next/navigation';
@@ -93,6 +94,13 @@ export default async function StackHandler<HasTokenStore extends boolean>(props:
     error: 'error',
   };
 
+  const pathAliases = {
+    // also includes the uppercase and non-dashed versions
+    ...Object.fromEntries(Object.entries(availablePaths).map(([key, value]) => [value, value])),
+    "log-in": availablePaths.signIn,
+    "register": availablePaths.signUp,
+  };
+
   const path = params.stack.join('/');
 
   const render = () => {
@@ -180,9 +188,12 @@ export default async function StackHandler<HasTokenStore extends boolean>(props:
         />;
       }
       default: {
-        for (const [key, value] of Object.entries(availablePaths)) {
-          if (path === value.replaceAll('-', '')) {
-            redirect(`${props.app.urls.handler}/${value}`, RedirectType.replace);
+        if (Object.values(availablePaths).includes(path)) {
+          throw new StackAssertionError(`Path alias ${path} not included in switch statement, but in availablePaths?`, { availablePaths });
+        }
+        for (const [key, value] of Object.entries(pathAliases)) {
+          if (path === key.toLowerCase().replaceAll('-', '')) {
+            redirect(`${props.app.urls.handler}/${value}?${new URLSearchParams(searchParams).toString()}`, RedirectType.replace);
           }
         }
         return notFound();


### PR DESCRIPTION
Neon Identity v2 changes as discussed with their team, where Neon can automatically provision a project and only later transfer it to a Stack Auth account; for this, we now have two endpoints /api/v1/integrations/neon/projects/provision (which creates a new project) and /api/v1/integrations/neon/projects/transfer/initiate (which returns a URL that can be used to transfer the project to a Stack Auth user account). Both require client_id:client_secret in basic authorization format, just like the OAuth flows.