### PR TITLE
Add `callbackUrl` to all functions that require a callback URL

### DIFF
--- a/packages/stack/src/lib/stack-app.ts
+++ b/packages/stack/src/lib/stack-app.ts
@@ -2063,7 +2063,6 @@ class _StackServerAppImpl<HasTokenStore extends boolean, ProjectId extends strin
     return this._serverUserFromCrud(crud);
   }
 
-
   async getUser(options: GetUserOptions<HasTokenStore> & { or: 'redirect' }): Promise<ProjectCurrentServerUser<ProjectId>>;
   async getUser(options: GetUserOptions<HasTokenStore> & { or: 'throw' }): Promise<ProjectCurrentServerUser<ProjectId>>;
   async getUser(options?: GetUserOptions<HasTokenStore>): Promise<ProjectCurrentServerUser<ProjectId> | null>;

--- a/packages/stack/src/lib/stack-app.ts
+++ b/packages/stack/src/lib/stack-app.ts
@@ -1761,7 +1761,7 @@ class _StackServerAppImpl<HasTokenStore extends boolean, ProjectId extends strin
       usedForAuth: crud.used_for_auth,
       async sendVerificationEmail(options?: { callbackUrl?: string }) {
         if (!options?.callbackUrl && typeof window === "undefined") {
-          throw new Error("Cannot invite user without a callback URL from the server. Make sure you pass the `callbackUrl` option: `inviteUser({ email, callbackUrl: ... })`");
+          throw new Error("Cannot send verification email without a callback URL from the server. Make sure you pass the `callbackUrl` option: `sendVerificationEmail({ callbackUrl: ... })`");
         }
 
         await app._interface.sendServerContactChannelVerificationEmail(userId, crud.id, options?.callbackUrl ?? constructRedirectUrl(app.urls.emailVerification));


### PR DESCRIPTION
Fixes #364 

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `callbackUrl` requirement to email functions in `_StackClientAppImpl` and `_StackServerAppImpl` when `window` is undefined.
> 
>   - **Behavior**:
>     - Updated `sendVerificationEmail`, `sendForgotPasswordEmail`, and `sendMagicLinkEmail` in `_StackClientAppImpl` to require `callbackUrl` if `window` is undefined.
>     - Removed `_sendVerificationEmail` method from `_StackClientAppImpl`.
>   - **Functions**:
>     - Modified `sendVerificationEmail` in `_StackServerAppImpl` to require `callbackUrl` if `window` is undefined.
>   - **Misc**:
>     - Updated type definitions for `sendForgotPasswordEmail` and `sendMagicLinkEmail` to include optional `callbackUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for 5f1fa44d30b0e313357e0418bc9e69e7cdcb1a94. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->