### PR TITLE
Neon webhook create

### DIFF
--- a/apps/backend/src/app/api/v1/integrations/neon/webhooks/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/webhooks/route.tsx
@@ -1,0 +1,42 @@
+import { getSvixClient } from "@/lib/webhooks";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, neonAuthorizationHeaderSchema, urlSchema, yupNumber, yupObject, yupString, yupTuple } from "@stackframe/stack-shared/dist/schema-fields";
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({
+      project: adaptSchema.defined(),
+    }).defined(),
+    body: yupObject({
+      url: urlSchema.defined(),
+      description: yupString().optional(),
+    }).defined(),
+    headers: yupObject({
+      authorization: yupTuple([neonAuthorizationHeaderSchema.defined()]).defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      secret: yupString().defined(),
+    }).defined(),
+  }),
+  handler: async ({ auth, body }) => {
+    const svix = getSvixClient(auth.project.id);
+    await svix.application.getOrCreate({ uid: auth.project.id, name: auth.project.id });
+    const endpoint = await svix.endpoint.create(auth.project.id, { url: body.url, description: body.description });
+    const secret = await svix.endpoint.getSecret(auth.project.id, endpoint.id);
+
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        secret: secret.key,
+      },
+    };
+  },
+});

--- a/apps/backend/src/app/api/v1/integrations/neon/webhooks/route.tsx
+++ b/apps/backend/src/app/api/v1/integrations/neon/webhooks/route.tsx
@@ -26,7 +26,7 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   handler: async ({ auth, body }) => {
-    const svix = getSvixClient(auth.project.id);
+    const svix = getSvixClient();
     await svix.application.getOrCreate({ uid: auth.project.id, name: auth.project.id });
     const endpoint = await svix.endpoint.create(auth.project.id, { url: body.url, description: body.description });
     const secret = await svix.endpoint.getSecret(auth.project.id, endpoint.id);

--- a/apps/backend/src/app/api/v1/webhooks/svix-token/route.tsx
+++ b/apps/backend/src/app/api/v1/webhooks/svix-token/route.tsx
@@ -7,7 +7,7 @@ import { createLazyProxy } from "@stackframe/stack-shared/dist/utils/proxies";
 const appPortalCrudHandlers = createLazyProxy(() => createCrudHandlers(svixTokenCrud, {
   paramsSchema: yupObject({}),
   onCreate: async ({ auth }) => {
-    const svix = getSvixClient(auth.project.id);
+    const svix = getSvixClient();
     await svix.application.getOrCreate({ uid: auth.project.id, name: auth.project.id });
     const result = await svix.authentication.appPortalAccess(auth.project.id, {});
     return { token: result.token };

--- a/apps/backend/src/app/api/v1/webhooks/svix-token/route.tsx
+++ b/apps/backend/src/app/api/v1/webhooks/svix-token/route.tsx
@@ -1,17 +1,13 @@
+import { getSvixClient } from "@/lib/webhooks";
 import { createCrudHandlers } from "@/route-handlers/crud-handler";
 import { svixTokenCrud } from "@stackframe/stack-shared/dist/interface/crud/svix-token";
 import { yupObject } from "@stackframe/stack-shared/dist/schema-fields";
-import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { createLazyProxy } from "@stackframe/stack-shared/dist/utils/proxies";
-import { Svix } from "svix";
 
 const appPortalCrudHandlers = createLazyProxy(() => createCrudHandlers(svixTokenCrud, {
   paramsSchema: yupObject({}),
   onCreate: async ({ auth }) => {
-    const svix = new Svix(
-      getEnvVariable("STACK_SVIX_API_KEY"),
-      { serverUrl: getEnvVariable("STACK_SVIX_SERVER_URL", "") || undefined }
-    );
+    const svix = getSvixClient(auth.project.id);
     await svix.application.getOrCreate({ uid: auth.project.id, name: auth.project.id });
     const result = await svix.authentication.appPortalAccess(auth.project.id, {});
     return { token: result.token };

--- a/apps/backend/src/lib/webhooks.tsx
+++ b/apps/backend/src/lib/webhooks.tsx
@@ -8,6 +8,13 @@ import { Result } from "@stackframe/stack-shared/dist/utils/results";
 import { Svix } from "svix";
 import * as yup from "yup";
 
+export function getSvixClient(projectId: string) {
+  return new Svix(
+    getEnvVariable("STACK_SVIX_API_KEY"),
+    { serverUrl: getEnvVariable("STACK_SVIX_SERVER_URL", "") || undefined }
+  );
+}
+
 async function sendWebhooks(options: {
   type: string,
   projectId: string,

--- a/apps/backend/src/lib/webhooks.tsx
+++ b/apps/backend/src/lib/webhooks.tsx
@@ -8,7 +8,7 @@ import { Result } from "@stackframe/stack-shared/dist/utils/results";
 import { Svix } from "svix";
 import * as yup from "yup";
 
-export function getSvixClient(projectId: string) {
+export function getSvixClient() {
   return new Svix(
     getEnvVariable("STACK_SVIX_API_KEY"),
     { serverUrl: getEnvVariable("STACK_SVIX_SERVER_URL", "") || undefined }

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/webhooks.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/webhooks.test.ts
@@ -1,0 +1,26 @@
+import { it } from "../../../../../../helpers";
+import { niceBackendFetch } from "../../../../../backend-helpers";
+import { provisionProject } from "./projects/provision.test";
+
+
+it("should be able to create a webhook", async ({ expect }) => {
+  await provisionProject();
+  const response = await niceBackendFetch("/api/v1/integrations/neon/webhooks", {
+    method: "POST",
+    body: {
+      url: "https://example.com/neon",
+      description: "Test webhook",
+    },
+    headers: {
+      "Authorization": "Basic bmVvbi1sb2NhbDpuZW9uLWxvY2FsLXNlY3JldA==",
+    },
+    accessType: "admin",
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": { "secret": <stripped field 'secret'> },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});

--- a/apps/e2e/tests/snapshot-serializer.ts
+++ b/apps/e2e/tests/snapshot-serializer.ts
@@ -42,6 +42,7 @@ const stripFields = [
   "attempt_code",
   "nonce",
   "authorization_code",
+  "secret",
 ] as const;
 
 const stripFieldsIfString = [

--- a/eslint-configs/defaults.js
+++ b/eslint-configs/defaults.js
@@ -71,7 +71,7 @@ module.exports = {
       },
       {
         selector:
-          "MemberExpression:has(Identifier[name='yupString']) Identifier[name='url']",
+          "MemberExpression:has(Identifier[name='yupString']) > Identifier[name='url']",
         message:
           "Use urlSchema from schema-fields.tsx instead of yupString().url().",
       },


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds Neon webhook creation route, refactors Svix client usage, and updates tests and ESLint rules.
> 
>   - **New Feature**:
>     - Adds `POST` route in `route.tsx` for creating Neon webhooks using `getSvixClient`.
>   - **Refactoring**:
>     - Replaces direct `Svix` instantiation with `getSvixClient` in `svix-token/route.tsx` and `webhooks.tsx`.
>   - **Testing**:
>     - Adds `webhooks.test.ts` to test Neon webhook creation.
>     - Updates `snapshot-serializer.ts` to strip `secret` field in snapshots.
>   - **Linting**:
>     - Fixes ESLint rule in `defaults.js` for `yupString` URL validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for 28dd696c058d4e02a814f9f2b03fe8586bca2f84. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->