### PR TITLE
Fixed separator display when only Passkey is enabled on the Sign In page

### DIFF
--- a/packages/stack/src/components-page/auth-page.tsx
+++ b/packages/stack/src/components-page/auth-page.tsx
@@ -85,7 +85,10 @@ function Inner (props: Props) {
     return <PredefinedMessageCard type='signUpDisabled' fullPage={props.fullPage} />;
   }
 
-  const enableSeparator = (project.config.credentialEnabled || project.config.magicLinkEnabled) && project.config.oauthProviders.length > 0;
+  const hasOAuthProviders = project.config.oauthProviders.length > 0;
+  const hasPasskey = (project.config.passkeyEnabled === true && props.type === "sign-in");
+  const hasSomeAuthMethod = hasOAuthProviders || hasPasskey;
+  const enableSeparator = (project.config.credentialEnabled || project.config.magicLinkEnabled) && hasSomeAuthMethod;
 
   return (
     <MaybeFullPage fullPage={!!props.fullPage}>
@@ -114,10 +117,12 @@ function Inner (props: Props) {
             </Typography>
           )}
         </div>
-        <div className='gap-4 flex flex-col items-stretch stack-scope'>
-          <OAuthButtonGroup type={props.type} mockProject={props.mockProject} />
-          {project.config.passkeyEnabled && props.type === "sign-in" && <PasskeyButton type={props.type} />}
-        </div>
+        {hasSomeAuthMethod && (
+          <div className='gap-4 flex flex-col items-stretch stack-scope'>
+            {hasOAuthProviders && <OAuthButtonGroup type={props.type} mockProject={props.mockProject} />}
+            {hasPasskey && <PasskeyButton type={props.type} />}
+          </div>
+        )}
 
         {enableSeparator && <SeparatorWithText text={t('Or continue with')} />}
         {project.config.credentialEnabled && project.config.magicLinkEnabled ? (
@@ -139,9 +144,12 @@ function Inner (props: Props) {
           props.type === 'sign-up' ? <CredentialSignUp noPasswordRepeat={props.noPasswordRepeat} /> : <CredentialSignIn/>
         ) : project.config.magicLinkEnabled ? (
           <MagicLinkSignIn/>
-        ) : project.config.oauthProviders.length === 0 ? <Typography variant={"destructive"} className="text-center">{t("No authentication method enabled.")}</Typography> : null}
+        ) : !hasSomeAuthMethod ? <Typography variant={"destructive"} className="text-center">{t("No authentication method enabled.")}</Typography> : null}
         {props.extraInfo && (
-          <div className='flex flex-col items-center text-center text-sm text-gray-500 mt-2'>
+          <div className={cn('flex flex-col items-center text-center text-sm text-gray-500', {
+            'mt-2': project.config.credentialEnabled || project.config.magicLinkEnabled,
+            'mt-6': !(project.config.credentialEnabled || project.config.magicLinkEnabled),
+          })}>
             <div>{props.extraInfo}</div>
           </div>
         )}

--- a/packages/stack/src/components-page/auth-page.tsx
+++ b/packages/stack/src/components-page/auth-page.tsx
@@ -87,8 +87,7 @@ function Inner (props: Props) {
 
   const hasOAuthProviders = project.config.oauthProviders.length > 0;
   const hasPasskey = (project.config.passkeyEnabled === true && props.type === "sign-in");
-  const hasSomeAuthMethod = hasOAuthProviders || hasPasskey;
-  const enableSeparator = (project.config.credentialEnabled || project.config.magicLinkEnabled) && hasSomeAuthMethod;
+  const enableSeparator = (project.config.credentialEnabled || project.config.magicLinkEnabled) && (hasOAuthProviders || hasPasskey);
 
   return (
     <MaybeFullPage fullPage={!!props.fullPage}>
@@ -117,7 +116,7 @@ function Inner (props: Props) {
             </Typography>
           )}
         </div>
-        {hasSomeAuthMethod && (
+        {(hasOAuthProviders || hasPasskey) && (
           <div className='gap-4 flex flex-col items-stretch stack-scope'>
             {hasOAuthProviders && <OAuthButtonGroup type={props.type} mockProject={props.mockProject} />}
             {hasPasskey && <PasskeyButton type={props.type} />}
@@ -144,7 +143,7 @@ function Inner (props: Props) {
           props.type === 'sign-up' ? <CredentialSignUp noPasswordRepeat={props.noPasswordRepeat} /> : <CredentialSignIn/>
         ) : project.config.magicLinkEnabled ? (
           <MagicLinkSignIn/>
-        ) : !hasSomeAuthMethod ? <Typography variant={"destructive"} className="text-center">{t("No authentication method enabled.")}</Typography> : null}
+        ) : !(hasOAuthProviders || hasPasskey) ? <Typography variant={"destructive"} className="text-center">{t("No authentication method enabled.")}</Typography> : null}
         {props.extraInfo && (
           <div className={cn('flex flex-col items-center text-center text-sm text-gray-500', {
             'mt-2': project.config.credentialEnabled || project.config.magicLinkEnabled,


### PR DESCRIPTION
If you turn off all oauth providers and enable passkey with email or email & password, the separator is not displayed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes separator display on Sign In page when only Passkey is enabled by updating logic in `auth-page.tsx`.
> 
>   - **Behavior**:
>     - Fixes separator display logic in `Inner` function of `auth-page.tsx` to show when Passkey is enabled without OAuth providers.
>     - Updates condition to render OAuth and Passkey buttons, ensuring they display correctly when either is enabled.
>   - **Logic**:
>     - Introduces `hasOAuthProviders` and `hasPasskey` variables to simplify conditions.
>     - Adjusts `enableSeparator` logic to account for Passkey being enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for efa673aed8fda1fc42ae5a82a3c86daa61de325a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->