### PR TITLE
fix: input mode

### DIFF
--- a/packages/stack-ui/src/components/ui/input-otp.tsx
+++ b/packages/stack-ui/src/components/ui/input-otp.tsx
@@ -13,6 +13,7 @@ const InputOTP: React.FC<React.ComponentPropsWithoutRef<typeof OTPInput>> = forw
 >(({ className, containerClassName, ...props }, ref) => (
   <OTPInput
     ref={ref}
+    inputMode="text"
     containerClassName={cn(
       "flex items-center gap-2 has-[:disabled]:opacity-50",
       containerClassName


### PR DESCRIPTION
the default input mode on https://github.com/guilhermerodz/input-otp is numeric but the OTP is composed by also letters

issue https://github.com/stack-auth/stack/issues/393

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `inputMode` to `text` in `InputOTP` to support alphanumeric OTPs.
> 
>   - **Behavior**:
>     - Change `inputMode` to `text` in `InputOTP` component in `input-otp.tsx` to support alphanumeric OTPs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for 81cc9225928f762f7c06ea339474cd1392be6914. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->