### PR TITLE
docs: fix streched image on deployed fern docs

### DIFF
--- a/docs/fern/style.css
+++ b/docs/fern/style.css
@@ -141,3 +141,7 @@ tr.stack-clickable-row-missing {
 .fern-sidebar-link-content > svg:last-child {
   display: none;
 }
+
+.stack-white-image-showcase > img {
+  object-fit: contain;
+}


### PR DESCRIPTION
I noticed a strange looking image in the docs. Here is a quick fix

<img width="925" alt="image" src="https://github.com/user-attachments/assets/9ce52726-173b-4553-b982-2d133effc6f5" />

This is appearing only on the deployed version of the docs not in development, so not tested.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix stretched image issue in deployed docs by adding `object-fit: contain;` to `.stack-white-image-showcase > img` in `style.css`.
> 
>   - **CSS Update**:
>     - In `style.css`, added `object-fit: contain;` to `.stack-white-image-showcase > img` to fix stretched image issue in deployed docs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for c48f9f5797eb5824102e8f77852a73c45f4ecd09. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->