### PR TITLE
remove trailing slash for NEXT_PUBLIC_STACK_URL

### DIFF
--- a/packages/template/src/lib/stack-app.ts
+++ b/packages/template/src/lib/stack-app.ts
@@ -130,7 +130,8 @@ function getDefaultSuperSecretAdminKey() {
 }
 
 function getDefaultBaseUrl() {
-  return process.env.NEXT_PUBLIC_STACK_API_URL || process.env.NEXT_PUBLIC_STACK_URL || defaultBaseUrl;
+  const url = process.env.NEXT_PUBLIC_STACK_API_URL || process.env.NEXT_PUBLIC_STACK_URL || defaultBaseUrl;
+  return url.endsWith('/') ? url.slice(0, -1) : url;
 }
 
 export type StackClientAppConstructorOptions<HasTokenStore extends boolean, ProjectId extends string> = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `getDefaultBaseUrl` in `stack-app.ts` now removes trailing slashes from URLs.
> 
>   - **Behavior**:
>     - `getDefaultBaseUrl` in `stack-app.ts` now removes trailing slash from URL if present.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for ecf1175b9821bfd79e825906cbaf100dfcd0c701. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->