### PR TITLE
add OTP to the subject line

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/otp/send-sign-in-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/otp/send-sign-in-code.test.ts
@@ -7,7 +7,7 @@ it("should send a sign-in code per e-mail", async ({ expect }) => {
     [
       MailboxMessage {
         "from": "Stack Dashboard <noreply@example.com>",
-        "subject": "Sign in to Stack Dashboard",
+        "subject": "Sign in to Stack Dashboard: Your code is <stripped code>",
         "to": ["<default-mailbox--<stripped UUID>@stack-generated.example.com>"],
         <some fields may have been hidden>,
       },

--- a/apps/e2e/tests/snapshot-serializer.ts
+++ b/apps/e2e/tests/snapshot-serializer.ts
@@ -115,6 +115,14 @@ const snapshotSerializer: SnapshotSerializer = {
           );
           if (newValue !== value) return nicify(newValue, options);
         }
+        // match something like "Your code is 34JXKG" and replace it with "Your code is <stripped code>"
+        if (typeof value === "string") {
+          const newValue = value.replace(
+            /Your code is [0-9A-Z]{6}/gi,
+            "Your code is <stripped code>"
+          );
+          if (newValue !== value) return nicify(newValue, options);
+        }
 
         // Strip URL query params
         const urlRegexHeuristic = /(?:(?:https?|ftp|file):\/\/|www\.|ftp\.)(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[A-Z0-9+&@#\/%=~_|$])/igm;

--- a/packages/stack-emails/src/utils.tsx
+++ b/packages/stack-emails/src/utils.tsx
@@ -45,7 +45,7 @@ export const EMAIL_TEMPLATES_METADATA = {
       ...projectVars,
       { name: 'emailVerificationLink', label: 'Email Verification Link', defined: true, example: '<email verification link>' },
     ],
-  } satisfies EmailTemplateMetadata,
+  },
   'password_reset': {
     label: "Password Reset",
     description: "Will be sent to the user when they request to reset their password (forgot password)",
@@ -56,19 +56,19 @@ export const EMAIL_TEMPLATES_METADATA = {
       ...projectVars,
       { name: 'passwordResetLink', label: 'Reset Password Link', defined: true, example: '<reset password link>' },
     ],
-  } satisfies EmailTemplateMetadata,
+  },
   'magic_link': {
     label: "Magic Link/OTP",
     description: "Will be sent to the user when they try to sign-up with magic link",
     defaultContent: { 1: magicLinkTemplateOld, 2: magicLinkTemplate },
-    defaultSubject: "Sign in to {{ projectDisplayName }}",
+    defaultSubject: "Sign in to {{ projectDisplayName }}: Your code is {{ otp }}",
     variables: [
       ...userVars,
       ...projectVars,
       { name: 'magicLink', label: 'Magic Link', defined: true, example: '<magic link>' },
       { name: 'otp', label: 'OTP', defined: true, example: '3SLSWZ' },
     ],
-  } satisfies EmailTemplateMetadata,
+  },
   'team_invitation': {
     label: "Team Invitation",
     description: "Will be sent to the user when they are invited to a team",
@@ -80,8 +80,8 @@ export const EMAIL_TEMPLATES_METADATA = {
       { name: 'teamDisplayName', label: 'Team Display Name', defined: true, example: 'My Team' },
       { name: 'teamInvitationLink', label: 'Team Invitation Link', defined: true, example: '<team invitation link>' },
     ],
-  } satisfies EmailTemplateMetadata,
-} as const;
+  },
+} as const satisfies Record<string, EmailTemplateMetadata>;
 
 export function validateEmailTemplateContent(content: any): content is TEditorConfiguration {
   try {


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update OTP email subject to include OTP code and adjust tests and snapshot serializer accordingly.
> 
>   - **Behavior**:
>     - Update OTP email subject in `utils.tsx` to include OTP code: "Sign in to {{ projectDisplayName }}: Your code is {{ otp }}".
>     - Modify test in `send-sign-in-code.test.ts` to expect new subject format.
>   - **Snapshot Serializer**:
>     - Add regex in `snapshot-serializer.ts` to strip OTP code from email subjects for consistent snapshots.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for fedbadf1e4fa78c2d1c03881ecb5fed630189977. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->