### PR TITLE
add metadata fields to `createStackUser` on `@stackframe/stack`

### DIFF
--- a/packages/template/src/lib/stack-app.ts
+++ b/packages/template/src/lib/stack-app.ts
@@ -3039,6 +3039,9 @@ type ServerUserCreateOptions = {
   otpAuthEnabled?: boolean,
   displayName?: string,
   primaryEmailVerified?: boolean,
+  clientMetadata?: any,
+  clientReadOnlyMetadata?: any,
+  serverMetadata?: any,
 }
 function serverUserCreateOptionsToCrud(options: ServerUserCreateOptions): UsersCrud["Server"]["Create"] {
   return {
@@ -3048,6 +3051,9 @@ function serverUserCreateOptionsToCrud(options: ServerUserCreateOptions): UsersC
     primary_email_auth_enabled: options.primaryEmailAuthEnabled,
     display_name: options.displayName,
     primary_email_verified: options.primaryEmailVerified,
+    client_metadata: options.clientMetadata,
+    client_read_only_metadata: options.clientReadOnlyMetadata,
+    server_metadata: options.serverMetadata,
   };
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add metadata fields to user creation options in `stack-app.ts`.
> 
>   - **Behavior**:
>     - Add `clientMetadata`, `clientReadOnlyMetadata`, and `serverMetadata` fields to `ServerUserCreateOptions` in `stack-app.ts`.
>     - Update `serverUserCreateOptionsToCrud()` to map new metadata fields to `UsersCrud["Server"]["Create"]`.
>   - **Misc**:
>     - No changes to existing functionality, only additions to support metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for 5a3dc9322dae1d0acb15de99df7a396e9b14ba03. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->