### PR TITLE
fix creator id

### DIFF
--- a/apps/backend/src/app/api/latest/teams/crud.tsx
+++ b/apps/backend/src/app/api/latest/teams/crud.tsx
@@ -35,24 +35,30 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
     team_id: yupString().uuid().defined(),
   }),
   onCreate: async ({ query, auth, data }) => {
+    let creatorUserId = data.creator_user_id;
+
     if (data.creator_user_id && query.add_current_user) {
       throw new StatusError(StatusError.BadRequest, "Cannot use both creator_user_id and add_current_user. add_current_user is deprecated, please only use creator_user_id in the body.");
     }
 
-    if (auth.type === 'client' && !auth.user) {
-      throw new KnownErrors.UserAuthenticationRequired;
-    }
+    if (auth.type === 'client') {
+      if (!auth.user) {
+        throw new KnownErrors.UserAuthenticationRequired;
+      }
 
-    if (auth.type === 'client' && !auth.tenancy.config.client_team_creation_enabled) {
-      throw new StatusError(StatusError.Forbidden, 'Client team creation is disabled for this project');
-    }
+      if (!auth.tenancy.config.client_team_creation_enabled) {
+        throw new StatusError(StatusError.Forbidden, 'Client team creation is disabled for this project');
+      }
 
-    if (auth.type === 'client' && data.profile_image_url && !validateBase64Image(data.profile_image_url)) {
-      throw new StatusError(400, "Invalid profile image URL");
-    }
+      if (data.profile_image_url && !validateBase64Image(data.profile_image_url)) {
+        throw new StatusError(400, "Invalid profile image URL");
+      }
 
-    if (auth.type === 'client' && (!data.creator_user_id || data.creator_user_id !== auth.user?.id)) {
-      throw new StatusError(StatusError.Forbidden, "You cannot create a team as a user that is not yourself. Make sure you set the creator_user_id to 'me'.");
+      if (!data.creator_user_id) {
+        creatorUserId = auth.user.id;
+      } else if (data.creator_user_id !== auth.user.id) {
+        throw new StatusError(StatusError.Forbidden, "You cannot create a team as a user that is not yourself. Make sure you set the creator_user_id to 'me'.");
+      }
     }
 
     const db = await retryTransaction(async (tx) => {

--- a/apps/backend/src/app/api/latest/teams/crud.tsx
+++ b/apps/backend/src/app/api/latest/teams/crud.tsx
@@ -35,7 +35,7 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
     team_id: yupString().uuid().defined(),
   }),
   onCreate: async ({ query, auth, data }) => {
-    let creatorUserId = data.creator_user_id;
+    let addUserId = data.creator_user_id;
 
     if (data.creator_user_id && query.add_current_user) {
       throw new StatusError(StatusError.BadRequest, "Cannot use both creator_user_id and add_current_user. add_current_user is deprecated, please only use creator_user_id in the body.");
@@ -55,10 +55,17 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
       }
 
       if (!data.creator_user_id) {
-        creatorUserId = auth.user.id;
+        addUserId = auth.user.id;
       } else if (data.creator_user_id !== auth.user.id) {
         throw new StatusError(StatusError.Forbidden, "You cannot create a team as a user that is not yourself. Make sure you set the creator_user_id to 'me'.");
       }
+    }
+
+    if (query.add_current_user === 'true') {
+      if (!auth.user) {
+        throw new StatusError(StatusError.Unauthorized, "You must be logged in to create a team with the current user as a member.");
+      }
+      addUserId = auth.user.id;
     }
 
     const db = await retryTransaction(async (tx) => {
@@ -74,22 +81,6 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
           serverMetadata: data.server_metadata === null ? Prisma.JsonNull : data.server_metadata,
         },
       });
-
-      let addUserId: string | undefined;
-      if (data.creator_user_id) {
-        if (auth.type === 'client') {
-          const currentUserId = auth.user?.id ?? throwErr(new KnownErrors.CannotGetOwnUserWithoutUser());
-          if (data.creator_user_id !== currentUserId) {
-            throw new StatusError(StatusError.Forbidden, "You cannot add a user to the team as the creator that is not yourself on the client.");
-          }
-        }
-        addUserId = data.creator_user_id;
-      } else if (query.add_current_user === 'true') {
-        if (!auth.user) {
-          throw new StatusError(StatusError.Unauthorized, "You must be logged in to create a team with the current user as a member.");
-        }
-        addUserId = auth.user.id;
-      }
 
       if (addUserId) {
         await ensureUserExists(tx, { tenancyId: auth.tenancy.id, userId: addUserId });

--- a/apps/e2e/tests/backend/endpoints/api/v1/teams.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/teams.test.ts
@@ -113,39 +113,6 @@ it("does not allow creating a team when not signed in", async ({ expect }) => {
   `);
 });
 
-it("does not allow creating teams on the client without a creator", async ({ expect }) => {
-  await Auth.Otp.signIn();
-  const response = await niceBackendFetch("/api/v1/teams", {
-    accessType: "client",
-    method: "POST",
-    body: {
-      display_name: "New Team",
-    },
-  });
-  expect(response).toMatchInlineSnapshot(`
-    NiceResponse {
-      "status": 400,
-      "body": {
-        "code": "SCHEMA_ERROR",
-        "details": {
-          "message": deindent\`
-            Request validation failed on POST /api/v1/teams:
-              - body.creator_user_id must be defined
-          \`,
-        },
-        "error": deindent\`
-          Request validation failed on POST /api/v1/teams:
-            - body.creator_user_id must be defined
-        \`,
-      },
-      "headers": Headers {
-        "x-stack-known-error": "SCHEMA_ERROR",
-        <some fields may have been hidden>,
-      },
-    }
-  `);
-});
-
 it("does not allow creating teams on the client for a different creator", async ({ expect }) => {
   const { userId: userId1 } = await Auth.Otp.signIn();
   await bumpEmailAddress();

--- a/packages/stack-shared/src/interface/crud/teams.ts
+++ b/packages/stack-shared/src/interface/crud/teams.ts
@@ -30,7 +30,7 @@ export const teamsCrudServerUpdateSchema = teamsCrudClientUpdateSchema.concat(yu
 // Create
 export const teamsCrudClientCreateSchema = teamsCrudClientUpdateSchema.concat(yupObject({
   display_name: fieldSchema.teamDisplayNameSchema.defined(),
-  creator_user_id: fieldSchema.teamCreatorUserIdSchema.defined(),
+  creator_user_id: fieldSchema.teamCreatorUserIdSchema.optional(),
 }).defined());
 export const teamsCrudServerCreateSchema = teamsCrudServerUpdateSchema.concat(yupObject({
   display_name: fieldSchema.teamDisplayNameSchema.defined(),


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes handling of `creator_user_id` in team creation, making it optional and ensuring proper validation and error handling.
> 
>   - **Behavior**:
>     - In `crud.tsx`, `creator_user_id` is now optional and defaults to `auth.user.id` if not provided.
>     - Throws `StatusError` if `creator_user_id` is set and does not match `auth.user.id`.
>     - Removes deprecated `add_current_user` logic.
>   - **Schema**:
>     - In `teams.ts`, `creator_user_id` is changed to optional in `teamsCrudClientCreateSchema` and `teamsCrudServerCreateSchema`.
>   - **Tests**:
>     - Removes test for creating teams without a creator in `teams.test.ts`.
>     - Adjusts tests to validate new `creator_user_id` behavior in `teams.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack&utm_source=github&utm_medium=referral)<sup> for 6580509e54c2521a821e7f03856202404674cd3e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->